### PR TITLE
feat(#52): embed step

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,6 +30,7 @@ on:
       - master
 env:
   HF_TESTING_TOKEN: ${{ secrets.HF_TESTING_TOKEN }}
+  COHERE_TESTING_TOKEN: ${{ secrets.COHERE_TESTING_TOKEN }}
 jobs:
   build:
     strategy:

--- a/README.md
+++ b/README.md
@@ -134,6 +134,24 @@ just extract after-filter.csv
 
 You should expect to have `sr-data/experiment/after-extract.csv`.
 
+### Generate Embeddings
+
+For each repo, we aggregate all [top words](#extract-headings) from README file
+headings into string. We convert each string to three variants of embeddings:
+[S-BERT], [E5], [Embedv3].
+
+To run this:
+
+```bash
+just embed after-extract.csv
+```
+
+You should expect to have three files:
+
+* `sr-data/experiment/embeddings-s-bert-384.csv`
+* `sr-data/experiment/embeddings-e5-1024.csv`
+* `sr-data/experiment/embeddings-embedv3-1024.csv`
+
 ## How to contribute
 
 Make sure that you have [Python 3.10+], [just], and [npm] installed on your
@@ -152,3 +170,6 @@ just full
 [Python 3.10+]: https://www.python.org/downloads/release/python-3100
 [npm]: https://docs.npmjs.com/downloading-and-installing-node-js-and-npm
 [just]: https://just.systems/man/en/chapter_4.html
+[S-BERT]: https://huggingface.co/sentence-transformers/all-MiniLM-L6-v2
+[E5]: https://huggingface.co/intfloat/e5-large
+[Embedv3]: https://cohere.com/blog/introducing-embed-v3

--- a/justfile
+++ b/justfile
@@ -55,7 +55,8 @@ check:
   mkdir -p sr-data/experiment
   mv now.txt sr-data/experiment/now.txt
   just collect
-  just filter
+  just filter experiment/repos.csv
+  just extract experiment/after-filter.csv
 
 # Clean up experiment.
 clean:
@@ -63,8 +64,6 @@ clean:
   rm sr-data/experiment/* && rmdir sr-data/experiment
 
 # Collect repositories.
-# Here, $PATS is a name of file with a number of GitHub PATs, separated
-# by new line.
 collect:
   mkdir -p sr-data/experiment
   ghminer --query "stars:>10 language:java size:>=20 mirror:false template:false" \
@@ -85,6 +84,15 @@ filter repos out="experiment/after-filter.csv":
 # Extract headings from README files.
 extract repos out="experiment/after-extract.csv":
   cd sr-data && poetry poe extract --repos {{repos}} --out {{out}}
+
+# Create embeddings.
+embed repos prefix="embeddings":
+  cd sr-data && poetry poe embed --repos {{repos}} --prefix {{prefix}} \
+    --key "$HF_TOKEN"
+
+# Calculate TF-IDF for README files.
+tfidf repos out="experiment/after-tfidf.csv":
+  cd sr-data && poetry poe tfidf --repos {{repos}} --out {{out}}
 
 # Build paper with LaTeX.
 paper:

--- a/justfile
+++ b/justfile
@@ -86,7 +86,7 @@ extract repos out="experiment/after-extract.csv":
   cd sr-data && poetry poe extract --repos {{repos}} --out {{out}}
 
 # Create embeddings.
-embed repos prefix="embeddings":
+embed repos prefix="experiment/embeddings":
   cd sr-data && poetry poe embed --repos {{repos}} --prefix {{prefix}} \
     --hf "$HF_TOKEN" --cohere "$COHERE_TOKEN"
 

--- a/justfile
+++ b/justfile
@@ -90,10 +90,6 @@ embed repos prefix="experiment/embeddings":
   cd sr-data && poetry poe embed --repos {{repos}} --prefix {{prefix}} \
     --hf "$HF_TOKEN" --cohere "$COHERE_TOKEN"
 
-# Calculate TF-IDF for README files.
-tfidf repos out="experiment/after-tfidf.csv":
-  cd sr-data && poetry poe tfidf --repos {{repos}} --out {{out}}
-
 # Build paper with LaTeX.
 paper:
   latexmk --version

--- a/justfile
+++ b/justfile
@@ -88,7 +88,7 @@ extract repos out="experiment/after-extract.csv":
 # Create embeddings.
 embed repos prefix="embeddings":
   cd sr-data && poetry poe embed --repos {{repos}} --prefix {{prefix}} \
-    --key "$HF_TOKEN"
+    --hf "$HF_TOKEN" --cohere "$COHERE_TOKEN"
 
 # Calculate TF-IDF for README files.
 tfidf repos out="experiment/after-tfidf.csv":

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,8 @@ sr-data = { path = "./sr-data" }
 sr-train = { path = "./sr-train" }
 sr-detector = { path = "./sr-detector" }
 nltk = "^3.9.1"
+scikit-learn = "^1.5.1"
+cohere = "^5.9.1"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^8.2.2"

--- a/sr-data/pyproject.toml
+++ b/sr-data/pyproject.toml
@@ -37,6 +37,7 @@ markdown = "^3.6"
 requests = "^2.32.3"
 nltk = "^3.9.1"
 scikit-learn = "^1.5.1"
+cohere = "^5.9.1"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^8.2.2"
@@ -54,8 +55,8 @@ script = "sr_data.tasks.tfidf:main(repos, out)"
 args = [{name = "repos"}, {name = "out"}]
 
 [tool.poe.tasks.embed]
-script = "sr_data.tasks.embed:main(repos, prefix, key)"
-args = [ {name = "repos"}, {name = "prefix"}, {name = "key"} ]
+script = "sr_data.tasks.embed:main(repos, prefix, hf, cohere)"
+args = [ {name = "repos"}, {name = "prefix"}, {name = "hf"}, {name = "cohere"} ]
 
 [tool.poetry.scripts]
 sr-data = "sr_data.all:main"

--- a/sr-data/pyproject.toml
+++ b/sr-data/pyproject.toml
@@ -36,6 +36,7 @@ beautifulsoup4 = "^4.12.3"
 markdown = "^3.6"
 requests = "^2.32.3"
 nltk = "^3.9.1"
+scikit-learn = "^1.5.1"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^8.2.2"
@@ -48,9 +49,13 @@ args = [{name = "repos"}, {name = "out"}]
 script = "sr_data.tasks.extract:main(repos, out)"
 args = [{name = "repos"}, {name = "out"}]
 
+[tool.poe.tasks.tfidf]
+script = "sr_data.tasks.tfidf:main(repos, out)"
+args = [{name = "repos"}, {name = "out"}]
+
 [tool.poe.tasks.embed]
-script = "sr_data.tasks.embed:main(key, checkpoint, csv, out)"
-args = [ {name = "key"}, {name = "checkpoint"}, {name = "csv"}, {name = "out"} ]
+script = "sr_data.tasks.embed:main(repos, prefix, key)"
+args = [ {name = "repos"}, {name = "prefix"}, {name = "key"} ]
 
 [tool.poetry.scripts]
 sr-data = "sr_data.all:main"

--- a/sr-data/src/sr_data/tasks/embed.py
+++ b/sr-data/src/sr_data/tasks/embed.py
@@ -25,26 +25,27 @@ Generate embeddings.
 import pandas as pd
 import requests
 
+models = {
+    "s-bert-384": "sentence-transformers/all-MiniLM-L6-v2",
+    "e5-1024": "intfloat/e5-large"
+}
 
-# @todo #9:45min JSONDecodeError Expecting value: line 1 column 1 (char 0) on
-#  some records in the CSV. When sending records to the endpoint, some READMEs
-#  get rejected with that error. We should identify that rows and possibly
-#  remove/recover them.
-def main(key, checkpoint, csv, out):
+
+def main(repos, prefix, key):
     """
     Embed.
     :param key: HuggingFace token
-    :param checkpoint: HuggingFace Inference checkpoint
-    :param csv: Source CSV
-    :param out: Output CSV
+    :param repos: Source CSV
+    :param prefix: Prefix for output CSV with embeddings
     """
-    frame = pd.read_csv(csv)
-    print(f"Generating embeddings for {frame}...")
-    print(f"Inference checkpoint: {checkpoint}")
-    embeddings = pd.DataFrame(infer(frame["readme"].tolist(), checkpoint, key))
-    embeddings.insert(0, 'repo', frame["repo"])
-    embeddings.to_csv(out, index=False)
-    print(f"Generated embeddings {out}")
+    frame = pd.read_csv(repos)
+    for model, checkpoint in models.items():
+        print(f"Generating {model} embeddings for {frame}...")
+        print(f"Inference checkpoint: {checkpoint}")
+        embeddings = pd.DataFrame(infer(frame["top"].tolist(), checkpoint, key))
+        embeddings.insert(0, 'repo', frame["repo"])
+        embeddings.to_csv(f"{prefix}-{model}", index=False)
+        print(f"Generated embeddings {prefix}-{model}")
 
 
 def infer(texts, checkpoint, key):

--- a/sr-data/src/sr_data/tasks/embed.py
+++ b/sr-data/src/sr_data/tasks/embed.py
@@ -26,6 +26,7 @@ import pandas as pd
 import requests
 import cohere
 import numpy as np
+from nltk.corpus import words
 
 models = {
     "s-bert-384": "sentence-transformers/all-MiniLM-L6-v2",
@@ -43,6 +44,10 @@ def main(repos, prefix, hf, cohere):
     :param cohere Cohere token
     """
     frame = pd.read_csv(repos)
+    frame["top"] = frame["top"].apply(
+        lambda words:
+            words.replace("[", "").replace("]", "").replace("'", "")
+    )
     for model, checkpoint in models.items():
         print(f"Generating {model} embeddings for {frame}...")
         if model == "cohere":

--- a/sr-data/src/tests/embed.csv
+++ b/sr-data/src/tests/embed.csv
@@ -1,2 +1,2 @@
-repo,readme
-foo,dummy README
+repo,top
+foo,"['test', 'dummy']"


### PR DESCRIPTION
In this pull, I've implemented embed step from Method section.

closes #52
History:
- **feat(#52): embed sent models**
- **feat(#52): cohere**
- **feat(#52): if cohere, test cases**
- **feat(#52): embed**

<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds functionality to generate embeddings for repositories using S-BERT, E5, and Embedv3 models. It also introduces the `COHERE_TESTING_TOKEN` secret.

### Detailed summary
- Added functionality to generate embeddings for repositories using different models
- Introduced `COHERE_TESTING_TOKEN` secret
- Updated `pyproject.toml` with dependencies for `scikit-learn` and `cohere`
- Updated `justfile` with new tasks for filtering and extracting data
- Updated `README.md` with instructions on how to run the new `just embed` task
- Updated `embed.py` to handle embedding generation for different models
- Added tests to ensure the generation of embeddings with different models

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->