### PR TITLE
feat(#55): remove repositories with 0 headings after regex filtering

### DIFF
--- a/sr-data/src/sr_data/tasks/embed.py
+++ b/sr-data/src/sr_data/tasks/embed.py
@@ -26,7 +26,6 @@ import pandas as pd
 import requests
 import cohere
 import numpy as np
-from nltk.corpus import words
 
 models = {
     "s-bert-384": "sentence-transformers/all-MiniLM-L6-v2",

--- a/sr-data/src/sr_data/tasks/extract.py
+++ b/sr-data/src/sr_data/tasks/extract.py
@@ -44,7 +44,8 @@ def main(repos, out):
     frame["headings"] = frame["readme"].apply(headings)
     before = len(frame)
     frame = frame.dropna(subset=["headings"])
-    print(f"Removed {before - len(frame)} repositories that don't have at least one heading (#)")
+    stops = len(frame)
+    print(f"Removed {before - stops} repositories that don't have at least one heading (#)")
     frame["headings"] = frame["headings"].apply(
         lambda readme: remove_stop_words(readme, stopwords.words("english"))
     )
@@ -53,6 +54,10 @@ def main(repos, out):
     )
     frame["headings"] = frame["headings"].apply(
         lambda headings: filter(headings, r"^[a-zA-Z]+$")
+    )
+    frame = frame[frame["headings"].apply(bool)]
+    print(
+        f"Removed {stops - len(frame)} repositories that have 0 headings after regex filtering"
     )
     frame["top"] = frame["headings"].apply(
         lambda headings: top_words(headings, 5)

--- a/sr-data/src/tests/test_extract.py
+++ b/sr-data/src/tests/test_extract.py
@@ -1,6 +1,7 @@
 """
 Test cases for extracting README headings (#).
 """
+import os
 # The MIT License (MIT)
 #
 # Copyright (c) 2024 Aliaksei Bialiauski
@@ -24,8 +25,9 @@ Test cases for extracting README headings (#).
 # SOFTWARE.
 import unittest
 
+import pandas as pd
 from nltk.corpus import stopwords
-from sr_data.tasks.extract import headings, remove_stop_words, lemmatize, filter, top_words
+from sr_data.tasks.extract import headings, remove_stop_words, lemmatize, filter, top_words, main
 
 
 class TestExtract(unittest.TestCase):
@@ -63,7 +65,7 @@ class TestExtract(unittest.TestCase):
     def test_filters(self):
         self.assertEqual(
             filter(
-                ["get start",";lt gt", ":;"],
+                ["get start", ";lt gt", ":;"],
                 r"^[a-zA-Z]+$"
             ),
             ["get", "start", "lt", "gt"],
@@ -80,4 +82,18 @@ class TestExtract(unittest.TestCase):
             top,
             expected,
             f"Top words found: {top}, but didn't match with expected: {expected}"
+        )
+
+    def test_filters_repo_with_empty_headings(self):
+        out = "extracted.csv"
+        main(
+            os.path.join(
+                os.path.dirname(os.path.realpath(__file__)), "to-extract.csv"
+            ),
+            out
+        )
+        self.assertEqual(
+            len(pd.read_csv(out)),
+            1,
+            "Should filter repo with empty headings"
         )

--- a/sr-data/src/tests/to-extract.csv
+++ b/sr-data/src/tests/to-extract.csv
@@ -1,0 +1,3 @@
+repo,readme
+jeff/foo,# Test # Foo # ;
+jeff/invalid,# ; # ; # ;


### PR DESCRIPTION
In this pull, I've implemented removal of repositories with 0 headings after regex filtering was applied.

closes #55 
History:
- **feat(#55): apply bool**
- **feat(#55): test case**


<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to enhance the data extraction process by improving filtering and handling of empty headings.

### Detailed summary
- Added filtering for repositories with empty headings
- Modified print statements for better clarity
- Updated test cases for new functionalities

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->