### PR TITLE
feat(#59): model save_config

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,10 +200,11 @@ directory:
 * `gmm`
 
 Each directory have its subs named after dataset name: `e5`, `embedv3`,
-`scores+sbert`, etc. In each subdirectory you should have `clusters` directory
-with files containing clustered repositories. Each file, for instance `0.txt`,
-where `0` is cluster identifier, hosts list of repositories in `OWNER/REPO`
-format, separated by new line:
+`scores+sbert`, etc. In each subdirectory you should have `config.json|txt`
+file with used model parameters, and `clusters` directory with files containing
+clustered repositories. Each file, for instance `0.txt`, where `0` is cluster
+identifier, hosts list of repositories in `OWNER/REPO` format, separated by new
+line:
 
 ```text
 Faceplugin-ltd/FaceRecognition-LivenessDetection-Android

--- a/sr-data/src/sr_data/steps/cluster.py
+++ b/sr-data/src/sr_data/steps/cluster.py
@@ -28,6 +28,7 @@ from pathlib import Path
 import pandas as pd
 from loguru import logger
 from sklearn.cluster import KMeans
+import json
 
 """
 Clustering random state.
@@ -53,12 +54,12 @@ def kmeans(dataset, dir):
     frame["cluster"] = kmeans.labels_
     prefix = f"{dir}/{Path(dataset).stem}"
     Path(f"{prefix}/clusters").mkdir(parents=True, exist_ok=True)
-    save_config(prefix, str(kmeans.get_params()))
+    save_config(prefix, json.dumps(kmeans.get_params(), indent=4), ".json")
     to_txt(frame.groupby("cluster"), f"{prefix}/clusters")
 
 
-def save_config(prefix, model):
-    full = f"{prefix}/config.txt"
+def save_config(prefix, model, ext):
+    full = f"{prefix}/config{ext}"
     with open(full, "w") as file:
         file.write(model)
     logger.info(f"Model settings saved to {full}")

--- a/sr-data/src/sr_data/steps/cluster.py
+++ b/sr-data/src/sr_data/steps/cluster.py
@@ -51,9 +51,17 @@ def kmeans(dataset, dir):
     centroids = kmeans.cluster_centers_
     logger.info(f"Centroids: {centroids}")
     frame["cluster"] = kmeans.labels_
-    prefix = f"{dir}/{Path(dataset).stem}/clusters"
-    Path(prefix).mkdir(parents=True, exist_ok=True)
-    to_txt(frame.groupby("cluster"), prefix)
+    prefix = f"{dir}/{Path(dataset).stem}"
+    Path(f"{prefix}/clusters").mkdir(parents=True, exist_ok=True)
+    save_config(prefix, str(kmeans.get_params()))
+    to_txt(frame.groupby("cluster"), f"{prefix}/clusters")
+
+
+def save_config(prefix, model):
+    full = f"{prefix}/config.txt"
+    with open(full, "w") as file:
+        file.write(model)
+    logger.info(f"Model settings saved to {full}")
 
 
 def to_txt(clusters, prefix):

--- a/sr-data/src/tests/test_cluster.py
+++ b/sr-data/src/tests/test_cluster.py
@@ -37,9 +37,15 @@ class TestCluster(unittest.TestCase):
             ),
             "kmeans"
         )
-        expected = "kmeans/to-cluster/clusters"
+        prefix = "kmeans/to-cluster"
+        expected = f"{prefix}/clusters"
         self.assertTrue(
             os.path.exists(expected),
             f"Path {expected} does not exists"
+        )
+        config = f"{prefix}/config.json"
+        self.assertTrue(
+            os.path.exists(config),
+            f"File {config} does not exists"
         )
         shutil.rmtree("kmeans")


### PR DESCRIPTION
In this pull, I've implemented saving used model's parameters saving to the file inside `experiment/${model}`.

ref #59
History:
- **feat(#59): config.txt**
- **feat(#59): json**
- **feat(#59): config**


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on improving the cluster testing and configuration saving functionality in the codebase.

### Detailed summary
- Updated test_cluster.py to include saving model configuration in config.json file
- Modified cluster.py to save model parameters in config.json
- Improved directory structure and file handling for clusters and config files

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->