### PR TITLE
feat(#65): loguru logger instead of prints

### DIFF
--- a/sr-data/src/sr_data/steps/combination.py
+++ b/sr-data/src/sr_data/steps/combination.py
@@ -25,6 +25,7 @@ Combination of two datasets.
 import os
 
 import pandas as pd
+from loguru import logger
 
 
 def main(scores, embeddings, dir):
@@ -35,7 +36,7 @@ def main(scores, embeddings, dir):
     :param dir: Output directory
     :return:
     """
-    print(f"Combining {scores} + {embeddings}")
+    logger.info(f"Combining {scores} + {embeddings}")
     out = (
         f"{dir}/{os.path.splitext(os.path.basename(scores))[0]}"
         f"+{os.path.splitext(os.path.basename(embeddings))[0]}.csv"
@@ -46,4 +47,4 @@ def main(scores, embeddings, dir):
         out,
         index=False
     )
-    print(f"Output dataset saved to {out}")
+    logger.info(f"Output dataset saved to {out}")

--- a/sr-data/src/sr_data/steps/embed.py
+++ b/sr-data/src/sr_data/steps/embed.py
@@ -26,6 +26,7 @@ import pandas as pd
 import requests
 import cohere
 import numpy as np
+from loguru import logger
 
 models = {
     "s-bert-384": "sentence-transformers/all-MiniLM-L6-v2",
@@ -45,18 +46,18 @@ def main(repos, prefix, hf, cohere):
     frame = pd.read_csv(repos)
     frame["top"] = frame["top"].apply(
         lambda words:
-            words.replace("[", "").replace("]", "").replace("'", "")
+        words.replace("[", "").replace("]", "").replace("'", "")
     )
     for model, checkpoint in models.items():
-        print(f"Generating {model} embeddings for {frame}...")
+        logger.info(f"Generating {model} embeddings for {frame}...")
         if model == "cohere":
             embed_cohere(cohere, frame, prefix)
         else:
-            print(f"Inference checkpoint: {checkpoint}")
+            logger.info(f"Inference checkpoint: {checkpoint}")
             embeddings = pd.DataFrame(infer(frame["top"].tolist(), checkpoint, hf))
             embeddings.insert(0, 'repo', frame["repo"])
             embeddings.to_csv(f"{prefix}-{model}.csv", index=False)
-        print(f"Generated embeddings {prefix}-{model}")
+        logger.info(f"Generated embeddings {prefix}-{model}")
 
 
 def embed_cohere(key, texts, prefix):

--- a/sr-data/src/sr_data/steps/extract.py
+++ b/sr-data/src/sr_data/steps/extract.py
@@ -27,6 +27,7 @@ from collections import Counter
 
 import nltk
 import pandas as pd
+from loguru import logger
 from nltk import WordNetLemmatizer, word_tokenize
 from nltk.corpus import stopwords, wordnet
 
@@ -39,13 +40,13 @@ lemmatizer = WordNetLemmatizer()
 
 
 def main(repos, out):
-    print("Extracting headings from README files...")
+    logger.info("Extracting headings from README files...")
     frame = pd.read_csv(repos)
     frame["headings"] = frame["readme"].apply(headings)
     before = len(frame)
     frame = frame.dropna(subset=["headings"])
     stops = len(frame)
-    print(f"Removed {before - stops} repositories that don't have at least one heading (#)")
+    logger.info(f"Removed {before - stops} repositories that don't have at least one heading (#)")
     frame["headings"] = frame["headings"].apply(
         lambda readme: remove_stop_words(readme, stopwords.words("english"))
     )
@@ -56,7 +57,7 @@ def main(repos, out):
         lambda headings: filter(headings, r"^[a-zA-Z]+$")
     )
     frame = frame[frame["headings"].apply(bool)]
-    print(
+    logger.info(
         f"Removed {stops - len(frame)} repositories that have 0 headings after regex filtering"
     )
     frame["top"] = frame["headings"].apply(

--- a/sr-data/src/sr_data/steps/filter.py
+++ b/sr-data/src/sr_data/steps/filter.py
@@ -27,6 +27,7 @@ import pandas as pd
 from bs4 import BeautifulSoup, ParserRejectedMarkup
 from langdetect import DetectorFactory, LangDetectException
 from langdetect import detect
+from loguru import logger
 
 
 def main(repos, out):
@@ -36,23 +37,23 @@ def main(repos, out):
     :param out: Output CSV file name
     :return: Filtered CSV
     """
-    print("Start filtering...")
+    logger.info("Start filtering...")
     DetectorFactory.seed = 0
     frame = pd.read_csv(repos)
     start = len(frame)
-    print(f"Repositories in {start}")
+    logger.info(f"Repositories in {start}")
     frame = frame.dropna(subset=["readme"])
     non_null = start - len(frame)
     after_null = len(frame)
-    print(f"Skipped {non_null} repositories with empty README files")
+    logger.info(f"Skipped {non_null} repositories with empty README files")
     frame["readme_text"] = frame["readme"].apply(md_to_text)
     frame = frame[frame["readme_text"].apply(english)]
     frame = frame.drop(columns=["readme_text"])
     non_english = after_null - len(frame)
-    print(f"Skipped {non_english} non-english repositories")
-    print(f"Total skipped: {non_null + non_english}")
-    print(f"Saving {len(frame)} good repositories to {out}")
-    print(frame)
+    logger.info(f"Skipped {non_english} non-english repositories")
+    logger.info(f"Total skipped: {non_null + non_english}")
+    logger.info(f"Saving {len(frame)} good repositories to {out}")
+    logger.debug(frame)
     frame.to_csv(out, index=False)
 
 

--- a/sr-data/src/sr_data/steps/scores.py
+++ b/sr-data/src/sr_data/steps/scores.py
@@ -23,13 +23,14 @@ Create datasets from repositories.
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 import pandas as pd
+from loguru import logger
 
 
 def main(repos, out):
     """
     Create datasets from repositories.
     """
-    print("Creating first dataset with scores...")
+    logger.info("Creating dataset with scores...")
     frame = pd.read_csv(repos)
     frame["score"] = (
             frame["releases"] * 50 +
@@ -40,4 +41,4 @@ def main(repos, out):
     )
     scores = frame[["repo", "score"]]
     scores.to_csv(out, index=False)
-    print(f"Scores dataset created in {out}")
+    logger.info(f"Scores dataset created in {out}")


### PR DESCRIPTION
closes #65 

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on replacing `print` statements with `logger` calls from the `loguru` library for better logging practices across multiple scripts in the `sr-data/src/sr_data/steps` directory.

### Detailed summary
- Added `logger` import from `loguru` in multiple files.
- Replaced `print` statements with `logger.info` for informational messages in:
  - `scores.py`
  - `combination.py`
  - `embed.py`
  - `extract.py`
  - `filter.py`
- Added `logger.debug` for displaying the `frame` in `filter.py`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->