### PR TITLE
feat(#59): cluster plain numerical dataset for experiment

### DIFF
--- a/justfile
+++ b/justfile
@@ -95,6 +95,7 @@ embed repos prefix="experiment/embeddings":
 
 # Create datasets.
 datasets dir="experiment":
+  just numerical "{{dir}}/after-extract.csv"
   just scores "{{dir}}/after-extract.csv"
   cp "sr-data/{{dir}}/embeddings-s-bert-384.csv" "sr-data/{{dir}}/sbert.csv"
   cp "sr-data/{{dir}}/embeddings-e5-1024.csv" "sr-data/{{dir}}/e5.csv"
@@ -107,6 +108,10 @@ datasets dir="experiment":
 scores repos out="experiment/scores.csv":
   cd sr-data && poetry poe scores --repos {{repos}} --out {{out}}
 
+# Create all numerical dataset.
+numerical repos out="experiment/numerical.csv":
+  cd sr-data && poetry poe numerical --repos {{repos}} --out {{out}}
+
 # Create dataset from combination.
 combination dir embeddings scores="experiment/scores.csv":
   cd sr-data && poetry poe combination --scores {{scores}} \
@@ -114,6 +119,7 @@ combination dir embeddings scores="experiment/scores.csv":
 
 # Cluster repositories.
 cluster dir="experiment":
+  cd sr-data && poetry poe cluster --dataset "experiment/numerical.csv" --dir {{dir}}
   cd sr-data && poetry poe cluster --dataset "experiment/scores.csv" --dir {{dir}}
   cd sr-data && poetry poe cluster --dataset "experiment/sbert.csv" --dir {{dir}}
   cd sr-data && poetry poe cluster --dataset "experiment/e5.csv" --dir {{dir}}

--- a/sr-data/pyproject.toml
+++ b/sr-data/pyproject.toml
@@ -59,6 +59,10 @@ args = [{name = "repos"}, {name = "out"}]
 script = "sr_data.steps.embed:main(repos, prefix, hf, cohere)"
 args = [ {name = "repos"}, {name = "prefix"}, {name = "hf"}, {name = "cohere"} ]
 
+[tool.poe.tasks.numerical]
+script = "sr_data.steps.numerical:main(repos, out)"
+args = [{name = "repos"}, {name = "out"}]
+
 [tool.poe.tasks.scores]
 script = "sr_data.steps.scores:main(repos, out)"
 args = [{name = "repos"}, {name = "out"}]

--- a/sr-data/src/sr_data/steps/numerical.py
+++ b/sr-data/src/sr_data/steps/numerical.py
@@ -1,5 +1,5 @@
 """
-Creates scores dataset from repositories.
+Create plain numerical dataset.
 """
 # The MIT License (MIT)
 #
@@ -27,18 +27,21 @@ from loguru import logger
 
 
 def main(repos, out):
-    """
-    Create datasets from repositories.
-    """
-    logger.info("Creating dataset with scores...")
+    logger.info("Creating dataset with all numerical data...")
     frame = pd.read_csv(repos)
-    frame["score"] = (
-            frame["releases"] * 50 +
-            frame["pulls"] * 7.5 +
-            frame["issues"] * 12.5 +
-            frame["branches"] * 30 +
-            frame["workflows"] * 10
-    )
-    scores = frame[["repo", "score"]]
-    scores.to_csv(out, index=False)
-    logger.info(f"Scores dataset created in {out}")
+    frame = frame[
+        [
+            "repo",
+            "releases",
+            "contributors",
+            "pulls",
+            "commits",
+            "issues",
+            "forks",
+            "stars",
+            "branches",
+            "workflows",
+        ]
+    ]
+    frame.to_csv(out, index=False)
+    logger.info(f"Numerical dataset created in {out}")


### PR DESCRIPTION
ref #59 

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enhancing the dataset creation process by introducing a new `numerical` task and updating documentation and scripts to reflect these changes.

### Detailed summary
- Updated the description in `scores.py` to specify it creates a scores dataset.
- Added a new task `[tool.poe.tasks.numerical]` in `pyproject.toml` for creating numerical datasets.
- Introduced a new `numerical` command in the `justfile` to create numerical datasets.
- Updated the `cluster` command to include the new numerical dataset.
- Added a new `main` function in `numerical.py` that logs the creation of a numerical dataset and saves it as a CSV file.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->