### PR TITLE
feat(#70): ignore android

### DIFF
--- a/justfile
+++ b/justfile
@@ -69,8 +69,8 @@ clean:
 # Collect repositories.
 collect:
   mkdir -p sr-data/experiment
-  ghminer --query "stars:>10 language:java size:>=20 mirror:false template:false" \
-    --start "2019-01-01" --end "2024-05-01" --tokens "$PATS" \
+  ghminer --query "stars:>10 language:java size:>=20 mirror:false template:false NOT android" \
+    --start "2024-01-01" --end "2024-05-01" --tokens "$PATS" \
     --filename "repos" && mv repos.csv sr-data/experiment/repos.csv
 
 # Collect test repositories.

--- a/justfile
+++ b/justfile
@@ -70,7 +70,7 @@ clean:
 collect:
   mkdir -p sr-data/experiment
   ghminer --query "stars:>10 language:java size:>=20 mirror:false template:false NOT android" \
-    --start "2024-01-01" --end "2024-05-01" --tokens "$PATS" \
+    --start "2019-01-01" --end "2024-05-01" --tokens "$PATS" \
     --filename "repos" && mv repos.csv sr-data/experiment/repos.csv
 
 # Collect test repositories.


### PR DESCRIPTION
closes #70

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the `justfile` to refine the query used by `ghminer` by excluding Android projects from the results.

### Detailed summary
- Modified the `ghminer` query by adding `NOT android` to filter out Android projects.
- The query now looks like this: `"stars:>10 language:java size:>=20 mirror:false template:false NOT android"`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->