### PR TITLE
feat(#68): experiment with fuzzy cmeans

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ nltk = "^3.9.1"
 scikit-learn = "^1.5.1"
 cohere = "^5.9.1"
 loguru = "^0.7.2"
+scikit-fuzzy = "^0.5.0"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^8.2.2"

--- a/sr-data/pyproject.toml
+++ b/sr-data/pyproject.toml
@@ -39,6 +39,7 @@ nltk = "^3.9.1"
 scikit-learn = "^1.5.1"
 cohere = "^5.9.1"
 loguru = "^0.7.2"
+scikit-fuzzy = "^0.5.0"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^8.2.2"

--- a/sr-data/src/sr_data/steps/cluster.py
+++ b/sr-data/src/sr_data/steps/cluster.py
@@ -60,6 +60,11 @@ def kmeans(dataset, dir):
 
 
 def cmeans(dataset, dir):
+    """
+    Fuzzy C-Means clustering
+    :param dataset: Dataset to cluster
+    :param dir: Output directory
+    """
     logger.info(f"Running Fuzzy C-Means for {dataset}")
     frame = pd.read_csv(dataset)
     centroids, u, u0, d, jm, p, fpc = skfuzzy.cmeans(
@@ -70,14 +75,13 @@ def cmeans(dataset, dir):
         maxiter=1000,
         init=None
     )
-    scores = u[0]
-    results = pd.DataFrame({
-        'repo': frame['repo'],
-        'srs': scores
-    })
     prefix = f"{dir}/{Path(dataset).stem}"
     Path(f"{prefix}/clusters").mkdir(parents=True, exist_ok=True)
-    results.to_csv(f"{prefix}/clusters/srs.csv", index=False)
+    out = f"{prefix}/clusters/srs.csv"
+    pd.DataFrame({"repo": frame["repo"], "srs": u[0]}).to_csv(
+        out, index=False
+    )
+    logger.info(f"Saved results to {out}")
 
 
 def save_config(prefix, model, ext):

--- a/sr-data/src/sr_data/steps/cluster.py
+++ b/sr-data/src/sr_data/steps/cluster.py
@@ -80,7 +80,6 @@ def cmeans(dataset, dir):
     results.to_csv(f"{prefix}/clusters/srs.csv", index=False)
 
 
-
 def save_config(prefix, model, ext):
     full = f"{prefix}/config{ext}"
     with open(full, "w") as file:

--- a/sr-data/src/tests/test_cluster.py
+++ b/sr-data/src/tests/test_cluster.py
@@ -25,7 +25,7 @@ Test case for cluster step.
 import os
 import shutil
 import unittest
-from sr_data.steps.cluster import kmeans
+from sr_data.steps.cluster import kmeans, cmeans
 
 
 class TestCluster(unittest.TestCase):
@@ -49,3 +49,18 @@ class TestCluster(unittest.TestCase):
             f"File {config} does not exists"
         )
         shutil.rmtree("kmeans")
+
+    def test_clusters_with_cmeans(self):
+        dir = "cmeans"
+        cmeans(
+            os.path.join(
+                os.path.dirname(os.path.realpath(__file__)), "to-cluster.csv"
+            ),
+            dir
+        )
+        file = "cmeans/to-cluster/clusters/srs.csv"
+        self.assertTrue(
+            os.path.exists(file),
+            f"C-Means results was not saved to {file}"
+        )
+        shutil.rmtree(dir)


### PR DESCRIPTION
In this pull I created experiment

closes #68
History:
- **feat(#68): cmeans**
- **feat(#68): clean**
- **feat(#68): cleaner**
- **feat(#68): test**


<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces the `scikit-fuzzy` library for implementing Fuzzy C-Means clustering in the project. It adds a new function for clustering and updates the test suite to validate this new functionality.

### Detailed summary
- Added `scikit-fuzzy` dependency in `pyproject.toml`.
- Introduced `cmeans` function in `sr_data/steps/cluster.py` for Fuzzy C-Means clustering.
- Updated `test_cluster.py` to include a new test for `cmeans`.
- Adjusted the `main` function to call `cmeans` alongside `kmeans`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->