### PR TITLE
feat(#33): pytest markers for fast, deep testing

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,4 +55,4 @@ jobs:
       - name: Build
         run: |
           just versions
-          just full slow
+          just full "deep or fast"

--- a/justfile
+++ b/justfile
@@ -28,9 +28,9 @@ versions:
   npm --version
 
 # Full build.
-full:
+full tests="fast":
   just install
-  just test
+  just test {{tests}}
   just check
 
 # Install dependencies.
@@ -39,8 +39,8 @@ install:
   npm install -g ghminer@0.0.5
 
 # Run tests.
-test:
-  poetry run pytest
+test which="fast":
+  poetry run pytest -m {{which}}
 
 # Check quality of source code.
 check:

--- a/justfile
+++ b/justfile
@@ -30,7 +30,7 @@ versions:
 # Full build.
 full tests="fast":
   just install
-  just test {{tests}}
+  just test "{{tests}}"
   just check
 
 # Install dependencies.
@@ -40,7 +40,7 @@ install:
 
 # Run tests.
 test which="fast":
-  poetry run pytest -m {{which}}
+  poetry run pytest -m "{{which}}"
 
 # Check quality of source code.
 check:

--- a/pytest.ini
+++ b/pytest.ini
@@ -23,5 +23,5 @@
 # Fast and Deep Testing: https://www.yegor256.com/2023/08/22/fast-vs-deep-testing.html
 [pytest]
 markers =
-    fast: unit test, usually fast.
-    slow: slow tests, designed to run on a servers.
+    fast: fast tests, usually are unit tests.
+    deep: deep tests, designed to run on a servers.

--- a/pytest.ini
+++ b/pytest.ini
@@ -19,40 +19,9 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
----
-name: build
-on:
-  push:
-    branches:
-      - master
-  pull_request:
-    branches:
-      - master
-env:
-  HF_TESTING_TOKEN: ${{ secrets.HF_TESTING_TOKEN }}
-  COHERE_TESTING_TOKEN: ${{ secrets.COHERE_TESTING_TOKEN }}
-jobs:
-  build:
-    strategy:
-      fail-fast: false
-      matrix:
-        python-version: [ "3.10", "3.11", "3.12" ]
-        poetry-version: [ "1.8.3" ]
-        os: [ ubuntu-22.04, macos-12, windows-2022 ]
-        just-version: [ "1.30.1" ]
-    runs-on: ${{ matrix.os }}
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
-        with:
-          python-version: ${{ matrix.python-version }}
-      - uses: abatilo/actions-poetry@v3
-        with:
-          poetry-version: ${{ matrix.poetry-version }}
-      - uses: extractions/setup-just@v2
-        with:
-          just-version: ${{ matrix.just-version }}
-      - name: Build
-        run: |
-          just versions
-          just full slow
+
+# Fast and Deep Testing: https://www.yegor256.com/2023/08/22/fast-vs-deep-testing.html
+[pytest]
+markers =
+    fast: unit test, usually fast.
+    slow: slow tests, designed to run on a servers.

--- a/sr-data/src/tests/test_cluster.py
+++ b/sr-data/src/tests/test_cluster.py
@@ -26,11 +26,13 @@ import os
 import unittest
 from tempfile import TemporaryDirectory
 
+import pytest
 from sr_data.steps.cluster import kmeans, cmeans
 
 
 class TestCluster(unittest.TestCase):
 
+    @pytest.mark.fast
     def test_clusters_kmeans_numerical(self):
         with TemporaryDirectory() as temp:
             kmeans(
@@ -51,6 +53,7 @@ class TestCluster(unittest.TestCase):
                 f"File {config} does not exists"
             )
 
+    @pytest.mark.fast
     def test_clusters_with_cmeans(self):
         with TemporaryDirectory() as temp:
             cmeans(

--- a/sr-data/src/tests/test_combination.py
+++ b/sr-data/src/tests/test_combination.py
@@ -25,10 +25,12 @@ from tempfile import TemporaryDirectory
 
 import pandas as pd
 from sr_data.steps.combination import main
+import pytest
 
 
 class TestCombination(unittest.TestCase):
 
+    @pytest.mark.fast
     def test_combines_into_dataset(self):
         with TemporaryDirectory() as temp:
             main(

--- a/sr-data/src/tests/test_embed.py
+++ b/sr-data/src/tests/test_embed.py
@@ -37,7 +37,7 @@ class TestEmbed(unittest.TestCase):
     Test cases for embed.
     """
 
-    @pytest.mark.slow
+    @pytest.mark.deep
     def test_returns_embeddings(self):
         """
         Test case for returning embeddings for text.
@@ -65,7 +65,7 @@ class TestEmbed(unittest.TestCase):
             f" expected {cexpected}"
         )
 
-    @pytest.mark.slow
+    @pytest.mark.deep
     def test_returns_e5_embeddings(self):
         embeddings = infer(
             ["some dummy text"],
@@ -90,7 +90,7 @@ class TestEmbed(unittest.TestCase):
             f" expected {cexpected}"
         )
 
-    @pytest.mark.slow
+    @pytest.mark.deep
     def test_creates_csv_with_embeddings(self):
         """
         Test case for checking generated CSV file with embeddings.

--- a/sr-data/src/tests/test_embed.py
+++ b/sr-data/src/tests/test_embed.py
@@ -28,6 +28,7 @@ from pathlib import Path
 from tempfile import TemporaryDirectory
 
 import pandas as pd
+import pytest
 from sr_data.steps.embed import infer, main
 
 
@@ -36,6 +37,7 @@ class TestEmbed(unittest.TestCase):
     Test cases for embed.
     """
 
+    @pytest.mark.slow
     def test_returns_embeddings(self):
         """
         Test case for returning embeddings for text.
@@ -63,6 +65,7 @@ class TestEmbed(unittest.TestCase):
             f" expected {cexpected}"
         )
 
+    @pytest.mark.slow
     def test_returns_e5_embeddings(self):
         embeddings = infer(
             ["some dummy text"],
@@ -87,6 +90,7 @@ class TestEmbed(unittest.TestCase):
             f" expected {cexpected}"
         )
 
+    @pytest.mark.slow
     def test_creates_csv_with_embeddings(self):
         """
         Test case for checking generated CSV file with embeddings.

--- a/sr-data/src/tests/test_extract.py
+++ b/sr-data/src/tests/test_extract.py
@@ -24,15 +24,17 @@ Test cases for extracting README headings (#).
 # SOFTWARE.
 import os
 import unittest
-from tempfile import TemporaryFile, TemporaryDirectory
+from tempfile import TemporaryDirectory
 
 import pandas as pd
+import pytest
 from nltk.corpus import stopwords
 from sr_data.steps.extract import headings, remove_stop_words, lemmatize, filter, top_words, main
 
 
 class TestExtract(unittest.TestCase):
 
+    @pytest.mark.fast
     def test_extracts_headings(self):
         heads = headings(
             """
@@ -49,6 +51,7 @@ class TestExtract(unittest.TestCase):
             f"README headings extracted: {heads}, but do not match with expected: {expected}"
         )
 
+    @pytest.mark.fast
     def test_removes_stop_words(self):
         self.assertEqual(
             remove_stop_words(["to", "it", "contribute"], stopwords.words("english")),
@@ -56,6 +59,7 @@ class TestExtract(unittest.TestCase):
             "Stop words was not removed"
         )
 
+    @pytest.mark.fast
     def test_lemmatizes_heading(self):
         self.assertEqual(
             lemmatize("Getting Started"),
@@ -63,6 +67,7 @@ class TestExtract(unittest.TestCase):
             "Heading was not lemmatized"
         )
 
+    @pytest.mark.fast
     def test_filters(self):
         self.assertEqual(
             filter(
@@ -73,6 +78,7 @@ class TestExtract(unittest.TestCase):
             "Headings were not filtered"
         )
 
+    @pytest.mark.fast
     def test_finds_top_3(self):
         top = top_words(
             ["get", "start", "get", "http", "gt", "gt"],
@@ -85,6 +91,7 @@ class TestExtract(unittest.TestCase):
             f"Top words found: {top}, but didn't match with expected: {expected}"
         )
 
+    @pytest.mark.fast
     def test_filters_repo_with_empty_headings(self):
         with TemporaryDirectory() as temp:
             path = os.path.join(temp, "testing.csv")

--- a/sr-data/src/tests/test_filter.py
+++ b/sr-data/src/tests/test_filter.py
@@ -28,10 +28,11 @@ from tempfile import TemporaryDirectory
 
 import pandas as pd
 from sr_data.steps.filter import main
-
+import pytest
 
 class TestFilter(unittest.TestCase):
 
+    @pytest.mark.fast
     def test_filters_input(self):
         """
         Test case for filtering input.

--- a/sr-data/src/tests/test_scores.py
+++ b/sr-data/src/tests/test_scores.py
@@ -24,11 +24,13 @@ import unittest
 from tempfile import TemporaryDirectory
 
 import pandas as pd
+import pytest
 from sr_data.steps.scores import main
 
 
 class TestScores(unittest.TestCase):
 
+    @pytest.mark.fast
     def test_calculates_score(self):
         with TemporaryDirectory() as temp:
             path = os.path.join(temp, "scores.csv")


### PR DESCRIPTION
closes #33

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces enhancements to the testing framework by adding `pytest` support, incorporating new test markers for fast and deep testing, and updating the build configuration to accommodate these changes.

### Detailed summary
- Added `pytest` to multiple test files.
- Introduced `@pytest.mark.fast` and `@pytest.mark.deep` markers for test categorization.
- Modified `justfile` to support fast and deep test execution.
- Updated the `pytest.ini` with licensing information and marker definitions.
- Enhanced several test classes with new test cases.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->