### PR TITLE
feat(#79): report nightly

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -29,8 +29,8 @@ env:
   HF_TESTING_TOKEN: ${{ secrets.HF_TESTING_TOKEN }}
   COHERE_TESTING_TOKEN: ${{ secrets.COHERE_TESTING_TOKEN }}
 jobs:
-  collect:
-    runs-on: ubuntu-24.04
+  build:
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
@@ -46,3 +46,13 @@ jobs:
         run: |
           just install
           just full "nightly or deep or fast"
+  report-fail:
+    name: Create issue on failure
+    needs: build
+    if: failure() && github.event.pull_request == null
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: jayqi/failed-build-issue-action@v1
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+22

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -55,4 +55,3 @@ jobs:
       - uses: jayqi/failed-build-issue-action@v1
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-22


### PR DESCRIPTION
ref #79

<!-- start pr-codex -->

---

## PR-Codex overview
This PR modifies the GitHub Actions workflow configuration in `.github/workflows/nightly.yml`. It updates the job names, changes the runner version, and adds a new job to create an issue on build failure.

### Detailed summary
- Renamed job from `collect` to `build`.
- Changed `runs-on` from `ubuntu-24.04` to `ubuntu-22.04`.
- Added a new job `report-fail` to create an issue on failure.
- Set `report-fail` to run on `ubuntu-22.04`.
- Included a step using `jayqi/failed-build-issue-action@v1` in `report-fail`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->