### PR TITLE
feat(#59): agglomerative

### DIFF
--- a/sr-data/src/tests/test_cluster.py
+++ b/sr-data/src/tests/test_cluster.py
@@ -27,7 +27,7 @@ import unittest
 from tempfile import TemporaryDirectory
 
 import pytest
-from sr_data.steps.cluster import kmeans, cmeans
+from sr_data.steps.cluster import kmeans, cmeans, agglomerative
 
 
 class TestCluster(unittest.TestCase):
@@ -66,4 +66,25 @@ class TestCluster(unittest.TestCase):
             self.assertTrue(
                 os.path.exists(file),
                 f"C-Means results was not saved to {file}"
+            )
+
+    @pytest.mark.fast
+    def test_clusters_with_agglomerative(self):
+        with TemporaryDirectory() as temp:
+            agglomerative(
+                os.path.join(
+                    os.path.dirname(os.path.realpath(__file__)), "to-cluster.csv"
+                ),
+                temp
+            )
+            path = os.path.join(temp, "to-cluster")
+            expected = f"{path}/clusters"
+            self.assertTrue(
+                os.path.exists(expected),
+                f"Directory: {expected} does not exists"
+            )
+            config = f"{path}/config.json"
+            self.assertTrue(
+                os.path.exists(config),
+                f"File {config} does not exists"
             )


### PR DESCRIPTION
In this pull, I've implemented Agglomerative clustering for `cluster` step.

ref #59 

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces an `agglomerative` clustering function and corresponding tests to the clustering module. It enhances the clustering capabilities by adding a new algorithm while also ensuring that the results are saved correctly.

### Detailed summary
- Added `agglomerative` function for clustering using `AgglomerativeClustering`.
- Introduced `save_clustered` function to handle saving clustered results.
- Updated `main` function to call `agglomerative`.
- Added a new test `test_clusters_with_agglomerative` in `test_cluster.py`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->