### PR TITLE
feat(#59): dbscan clustering

### DIFF
--- a/sr-data/src/sr_data/steps/cluster.py
+++ b/sr-data/src/sr_data/steps/cluster.py
@@ -29,7 +29,7 @@ from pathlib import Path
 import pandas as pd
 import skfuzzy
 from loguru import logger
-from sklearn.cluster import KMeans, AgglomerativeClustering
+from sklearn.cluster import KMeans, AgglomerativeClustering, DBSCAN
 
 """
 Clustering random state.
@@ -59,6 +59,14 @@ def agglomerative(dataset, dir):
     logger.info(f"Running Agglomerative clustering for {dataset}")
     frame = pd.read_csv(dataset)
     model = AgglomerativeClustering(n_clusters=3)
+    model.fit(frame.drop(columns=["repo"]))
+    save_clustered(model, frame, f"{dir}/{Path(dataset).stem}")
+
+
+def dbscan(dataset, dir):
+    logger.info(f"Running DBSCAN for {dataset}")
+    frame = pd.read_csv(dataset)
+    model = DBSCAN(eps=0.5, min_samples=5)
     model.fit(frame.drop(columns=["repo"]))
     save_clustered(model, frame, f"{dir}/{Path(dataset).stem}")
 
@@ -119,4 +127,5 @@ def main(dataset, dir):
     """
     kmeans(dataset, f"{dir}/kmeans")
     agglomerative(dataset, f"{dir}/agglomerative")
+    dbscan(dataset, f"{dir}/dbscan")
     cmeans(dataset, f"{dir}/cmeans")

--- a/sr-data/src/tests/test_cluster.py
+++ b/sr-data/src/tests/test_cluster.py
@@ -27,7 +27,7 @@ import unittest
 from tempfile import TemporaryDirectory
 
 import pytest
-from sr_data.steps.cluster import kmeans, cmeans, agglomerative
+from sr_data.steps.cluster import kmeans, cmeans, agglomerative, dbscan
 
 
 class TestCluster(unittest.TestCase):
@@ -72,6 +72,27 @@ class TestCluster(unittest.TestCase):
     def test_clusters_with_agglomerative(self):
         with TemporaryDirectory() as temp:
             agglomerative(
+                os.path.join(
+                    os.path.dirname(os.path.realpath(__file__)), "to-cluster.csv"
+                ),
+                temp
+            )
+            path = os.path.join(temp, "to-cluster")
+            expected = f"{path}/clusters"
+            self.assertTrue(
+                os.path.exists(expected),
+                f"Directory: {expected} does not exists"
+            )
+            config = f"{path}/config.json"
+            self.assertTrue(
+                os.path.exists(config),
+                f"File {config} does not exists"
+            )
+
+    @pytest.mark.fast
+    def test_clusters_with_dbscan(self):
+        with TemporaryDirectory() as temp:
+            dbscan(
                 os.path.join(
                     os.path.dirname(os.path.realpath(__file__)), "to-cluster.csv"
                 ),


### PR DESCRIPTION
In this pull, I've implemented DBSCAN clustering in `cluster` step.

ref #59
History:
- **feat(#59): dbscan**
- **feat(#59): dbscan**


<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces the `DBSCAN` clustering algorithm to the project, adding functionality for clustering data using this method and updating related tests.

### Detailed summary
- Added `DBSCAN` import in `sr-data/src/sr_data/steps/cluster.py`.
- Implemented `dbscan` function for clustering in `sr-data/src/sr_data/steps/cluster.py`.
- Updated `main` function to call `dbscan`.
- Added `test_clusters_with_dbscan` test in `sr-data/src/tests/test_cluster.py`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->