### PR TITLE
feat(#59): gmm clustering

### DIFF
--- a/sr-data/src/tests/test_cluster.py
+++ b/sr-data/src/tests/test_cluster.py
@@ -27,7 +27,7 @@ import unittest
 from tempfile import TemporaryDirectory
 
 import pytest
-from sr_data.steps.cluster import kmeans, cmeans, agglomerative, dbscan
+from sr_data.steps.cluster import kmeans, cmeans, agglomerative, dbscan, gmm
 
 
 class TestCluster(unittest.TestCase):
@@ -93,6 +93,27 @@ class TestCluster(unittest.TestCase):
     def test_clusters_with_dbscan(self):
         with TemporaryDirectory() as temp:
             dbscan(
+                os.path.join(
+                    os.path.dirname(os.path.realpath(__file__)), "to-cluster.csv"
+                ),
+                temp
+            )
+            path = os.path.join(temp, "to-cluster")
+            expected = f"{path}/clusters"
+            self.assertTrue(
+                os.path.exists(expected),
+                f"Directory: {expected} does not exists"
+            )
+            config = f"{path}/config.json"
+            self.assertTrue(
+                os.path.exists(config),
+                f"File {config} does not exists"
+            )
+
+    @pytest.mark.fast
+    def test_clusters_with_gmm(self):
+        with TemporaryDirectory() as temp:
+            gmm(
                 os.path.join(
                     os.path.dirname(os.path.realpath(__file__)), "to-cluster.csv"
                 ),


### PR DESCRIPTION
In this pull, I've implemented GMM clustering in `cluster` step.

closes #59 
History:
- **feat(#59): gmm**
- **feat(#59): gmm**


<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces a new clustering method using Gaussian Mixture Models (`gmm`) and adds a corresponding test case for it. It also updates the clustering functions to include `gmm` in the main execution flow.

### Detailed summary
- Added import of `GaussianMixture` from `sklearn.mixture`.
- Implemented `gmm` function for clustering using Gaussian Mixture Models.
- Added a new test method `test_clusters_with_gmm` in `TestCluster` to validate `gmm` functionality.
- Updated the main function to call `gmm` alongside other clustering methods.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->