### PR TITLE
feat(#102): SSL via lpm

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,9 +43,6 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
-      - name: Install distutils for Python 3.12
-        run: |
-          python -m pip install --upgrade pip setuptools
       - uses: abatilo/actions-poetry@v3
         with:
           poetry-version: ${{ matrix.poetry-version }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,6 +43,11 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
+      - name: Install distutils for Python 3.12
+        if: matrix.python-version == '3.12' && startsWith(matrix.os, 'ubuntu')
+        run: |
+          sudo apt-get update
+          sudo apt-get install python3-distutils
       - uses: abatilo/actions-poetry@v3
         with:
           poetry-version: ${{ matrix.poetry-version }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,10 +44,8 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install distutils for Python 3.12
-        if: matrix.python-version == '3.12' && startsWith(matrix.os, 'ubuntu')
         run: |
-          sudo apt-get update
-          sudo apt-get install python3-distutils
+          python -m pip install --upgrade pip setuptools
       - uses: abatilo/actions-poetry@v3
         with:
           poetry-version: ${{ matrix.poetry-version }}

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -23,7 +23,7 @@
 name: nightly
 on:
   schedule:
-    # Run load testing at 3:00 UTC every day
+    # Run deep testing at 3:00 UTC every day
     - cron: '0 3 * * *'
 permissions:
   issues: write

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -25,6 +25,8 @@ on:
   schedule:
     # Run load testing at 3:00 UTC every day
     - cron: '0 3 * * *'
+permissions:
+  issues: write
 env:
   HF_TESTING_TOKEN: ${{ secrets.HF_TESTING_TOKEN }}
   COHERE_TESTING_TOKEN: ${{ secrets.COHERE_TESTING_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -34,8 +34,6 @@ textual. For numerical we collect:
 * `pulls`, the number of pull requests.
 * `issues`, the total number of issues (opened + closed).
 * `branches`, the number of branches.
-* `actions`, the number of GitHub Actions workflow files.
-For textual: `README.md` file.
 
 To run this:
 
@@ -54,6 +52,8 @@ just test-collect
 
 You should expect to have `sr-data/tmp/test-repos.csv`, with the same structure
 as `repos.csv`, but smaller.
+
+You can run this step in GitHub Actions: [collect.yml].
 
 ### Filter
 
@@ -242,3 +242,4 @@ just full
 [Agglomerative clustering]: https://en.wikipedia.org/wiki/Hierarchical_clustering
 [DBSCAN]: https://en.wikipedia.org/wiki/DBSCAN
 [GMM]: https://en.wikipedia.org/wiki/Mixture_model
+[collect.yml]: https://github.com/h1alexbel/sr-detection/actions/workflows/collect.yml

--- a/justfile
+++ b/justfile
@@ -22,8 +22,6 @@
 
 # Install dependencies.
 install:
-  pip3 install setuptools
-  poetry update
   npm install -g ghminer@0.0.6
 
 # Full build.

--- a/justfile
+++ b/justfile
@@ -22,7 +22,6 @@
 
 # Install dependencies.
 install:
-  pip install --upgrade setuptools
   npm install -g ghminer@0.0.6
 
 # Full build.

--- a/justfile
+++ b/justfile
@@ -121,8 +121,15 @@ cluster dir="experiment":
   cd sr-data && poetry poe cluster --dataset "experiment/scores+embedv3.csv" --dir {{dir}}
 
 # Fill in labels in repositories dataset.
-labels repos out="experiment/labels.csv":
-  cd sr-data && poetry poe labels --repos {{repos}} --out {{out}}
+labels dir="experiment":
+  cd sr-data && poetry poe labels --repos "experiment/numerical.csv" --dir {{dir}}
+  cd sr-data && poetry poe labels --repos "experiment/scores.csv" --dir {{dir}}
+  cd sr-data && poetry poe labels --repos "experiment/sbert.csv" --dir {{dir}}
+  cd sr-data && poetry poe labels --repos "experiment/e5.csv" --dir {{dir}}
+  cd sr-data && poetry poe labels --repos "experiment/embedv3.csv" --dir {{dir}}
+  cd sr-data && poetry poe labels --repos "experiment/scores+sbert.csv" --dir {{dir}}
+  cd sr-data && poetry poe labels --repos "experiment/scores+e5.csv" --dir {{dir}}
+  cd sr-data && poetry poe labels --repos "experiment/scores+embedv3.csv" --dir {{dir}}
 
 # Build paper with LaTeX.
 paper:

--- a/justfile
+++ b/justfile
@@ -131,6 +131,10 @@ labels dir="experiment":
   cd sr-data && poetry poe labels --repos "experiment/scores+e5.csv" --dir {{dir}}
   cd sr-data && poetry poe labels --repos "experiment/scores+embedv3.csv" --dir {{dir}}
 
+# Semi Supervised Learning experiment.
+ssl repos out:
+  cd sr-data && poetry poe ssl --repos {{repos}} --out {{out}}
+
 # Build paper with LaTeX.
 paper:
   latexmk --version

--- a/justfile
+++ b/justfile
@@ -120,6 +120,10 @@ cluster dir="experiment":
   cd sr-data && poetry poe cluster --dataset "experiment/scores+e5.csv" --dir {{dir}}
   cd sr-data && poetry poe cluster --dataset "experiment/scores+embedv3.csv" --dir {{dir}}
 
+# Fill in labels in repositories dataset.
+labels repos out="experiment/labels.csv":
+  cd sr-data && poetry poe labels --repos {{repos}} --out {{out}}
+
 # Build paper with LaTeX.
 paper:
   latexmk --version

--- a/justfile
+++ b/justfile
@@ -131,9 +131,9 @@ labels dir="experiment":
   cd sr-data && poetry poe labels --repos "experiment/scores+e5.csv" --dir {{dir}}
   cd sr-data && poetry poe labels --repos "experiment/scores+embedv3.csv" --dir {{dir}}
 
-# Semi Supervised Learning experiment.
-ssl repos out:
-  cd sr-data && poetry poe ssl --repos {{repos}} --out {{out}}
+# Label Propagation model training on repos `repos`, should be saved to `out`.
+lpm repos out:
+  cd sr-data && poetry poe lpm --repos {{repos}} --out {{out}}
 
 # Build paper with LaTeX.
 paper:

--- a/justfile
+++ b/justfile
@@ -23,6 +23,7 @@
 # Install dependencies.
 install:
   pip3 install setuptools
+  poetry update
   npm install -g ghminer@0.0.6
 
 # Full build.

--- a/justfile
+++ b/justfile
@@ -22,6 +22,7 @@
 
 # Install dependencies.
 install:
+  pip3 install setuptools
   npm install -g ghminer@0.0.6
 
 # Full build.

--- a/justfile
+++ b/justfile
@@ -22,6 +22,7 @@
 
 # Install dependencies.
 install:
+  pip install --upgrade setuptools
   npm install -g ghminer@0.0.6
 
 # Full build.

--- a/sr-data/pyproject.toml
+++ b/sr-data/pyproject.toml
@@ -77,8 +77,8 @@ script = "sr_data.steps.cluster:main(dataset, dir)"
 args = [{name = "dataset"}, {name = "dir"}]
 
 [tool.poe.tasks.labels]
-script = "sr_data.steps.labels:main(repos, out)"
-args = [{name = "repos"}, {name = "out"}]
+script = "sr_data.steps.labels:main(repos, dir)"
+args = [{name = "repos"}, {name = "dir"}]
 
 [build-system]
 requires = ["setuptools", "wheel"]

--- a/sr-data/pyproject.toml
+++ b/sr-data/pyproject.toml
@@ -37,7 +37,7 @@ markdown = "^3.6"
 requests = "^2.32.3"
 nltk = "^3.9.1"
 scikit-learn = "^1.5.1"
-cohere = "^5.9.1"
+cohere = "5.9.1"
 loguru = "^0.7.2"
 scikit-fuzzy = "^0.5.0"
 

--- a/sr-data/pyproject.toml
+++ b/sr-data/pyproject.toml
@@ -80,6 +80,10 @@ args = [{name = "dataset"}, {name = "dir"}]
 script = "sr_data.steps.labels:main(repos, dir)"
 args = [{name = "repos"}, {name = "dir"}]
 
+[tool.poe.tasks.ssl]
+script = "sr_data.steps.label_propagation:main(repos, out)"
+args = [{name = "repos"}, {name = "out"}]
+
 [build-system]
 requires = ["setuptools", "wheel"]
 build-backend = "setuptools.build_meta"

--- a/sr-data/pyproject.toml
+++ b/sr-data/pyproject.toml
@@ -76,6 +76,10 @@ args = [{name = "scores"}, {name = "embeddings"}, {name = "dir"}]
 script = "sr_data.steps.cluster:main(dataset, dir)"
 args = [{name = "dataset"}, {name = "dir"}]
 
+[tool.poe.tasks.labels]
+script = "sr_data.steps.labels:main(repos, out)"
+args = [{name = "repos"}, {name = "out"}]
+
 [build-system]
 requires = ["setuptools", "wheel"]
 build-backend = "setuptools.build_meta"

--- a/sr-data/pyproject.toml
+++ b/sr-data/pyproject.toml
@@ -80,7 +80,7 @@ args = [{name = "dataset"}, {name = "dir"}]
 script = "sr_data.steps.labels:main(repos, dir)"
 args = [{name = "repos"}, {name = "dir"}]
 
-[tool.poe.tasks.ssl]
+[tool.poe.tasks.lpm]
 script = "sr_data.steps.label_propagation:main(repos, out)"
 args = [{name = "repos"}, {name = "out"}]
 

--- a/sr-data/src/sr_data/steps/label_propagation.py
+++ b/sr-data/src/sr_data/steps/label_propagation.py
@@ -1,0 +1,21 @@
+import joblib
+import pandas as pd
+from loguru import logger
+from sklearn.preprocessing import StandardScaler
+from sklearn.semi_supervised import LabelPropagation
+
+
+def main(repos, out):
+    frame = pd.read_csv(repos)
+    frame['label'] = frame['label'].map({'SR': 1, 'NON': 0}).fillna(-1)
+    features = frame.drop(columns=["repo", "label"])
+    scaler = StandardScaler()
+    scaled = scaler.fit_transform(features)
+    model = LabelPropagation()
+    model.fit(scaled, frame["label"])
+    joblib.dump(model, out)
+    logger.info(f"Model {model} saved to {out}")
+    probs = model.predict_proba(scaled)
+    for i, prob in enumerate(probs):
+        rid = frame["repo"].iloc[i]
+        logger.info(f"Repo {rid}: {prob[1]:.2f}")

--- a/sr-data/src/sr_data/steps/label_propagation.py
+++ b/sr-data/src/sr_data/steps/label_propagation.py
@@ -1,3 +1,27 @@
+"""
+Trains Label Propagation model, and saves it.
+"""
+# The MIT License (MIT)
+#
+# Copyright (c) 2024 Aliaksei Bialiauski
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
 import joblib
 import pandas as pd
 from loguru import logger
@@ -8,9 +32,9 @@ from sklearn.semi_supervised import LabelPropagation
 def main(repos, out):
     frame = pd.read_csv(repos)
     frame['label'] = frame['label'].map({'SR': 1, 'NON': 0}).fillna(-1)
-    features = frame.drop(columns=["repo", "label"])
-    scaler = StandardScaler()
-    scaled = scaler.fit_transform(features)
+    scaled = StandardScaler().fit_transform(
+        frame.drop(columns=["repo", "label"])
+    )
     model = LabelPropagation()
     model.fit(scaled, frame["label"])
     joblib.dump(model, out)

--- a/sr-data/src/sr_data/steps/labels.py
+++ b/sr-data/src/sr_data/steps/labels.py
@@ -1,0 +1,34 @@
+"""
+Labels.
+"""
+# The MIT License (MIT)
+#
+# Copyright (c) 2024 Aliaksei Bialiauski
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+import pandas as pd
+from loguru import logger
+
+
+def main(repos, out):
+    logger.info("Filling in NULL labels...")
+    frame = pd.read_csv(repos)
+    frame["label"] = None
+    frame.to_csv(out, index=False)
+    logger.info(f"Saved copy with labels column to {out}")

--- a/sr-data/src/sr_data/steps/labels.py
+++ b/sr-data/src/sr_data/steps/labels.py
@@ -1,6 +1,8 @@
 """
 Labels.
 """
+from pathlib import Path
+
 # The MIT License (MIT)
 #
 # Copyright (c) 2024 Aliaksei Bialiauski
@@ -26,9 +28,10 @@ import pandas as pd
 from loguru import logger
 
 
-def main(repos, out):
+def main(repos, dir):
     logger.info("Filling in NULL labels...")
     frame = pd.read_csv(repos)
     frame["label"] = None
+    out = f"{dir}/{Path(repos).stem}-labels.csv"
     frame.to_csv(out, index=False)
     logger.info(f"Saved copy with labels column to {out}")

--- a/sr-data/src/tests/test_labels.py
+++ b/sr-data/src/tests/test_labels.py
@@ -1,0 +1,46 @@
+"""
+Test case for labels.
+"""
+# The MIT License (MIT)
+#
+# Copyright (c) 2024 Aliaksei Bialiauski
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+import os
+import unittest
+from tempfile import TemporaryDirectory
+
+import pandas as pd
+import pytest
+from sr_data.steps.labels import main
+
+class TestLabels(unittest.TestCase):
+
+    @pytest.mark.fast
+    def test_adds_label_column(self):
+        with TemporaryDirectory() as temp:
+            path = os.path.join(temp, "with-labels.csv")
+            main(
+                os.path.join(
+                    os.path.dirname(os.path.realpath(__file__)),
+                    "scores.csv"
+                ),
+                path
+            )
+            self.assertTrue("label" in pd.read_csv(path).columns)

--- a/sr-data/src/tests/test_labels.py
+++ b/sr-data/src/tests/test_labels.py
@@ -35,12 +35,11 @@ class TestLabels(unittest.TestCase):
     @pytest.mark.fast
     def test_adds_label_column(self):
         with TemporaryDirectory() as temp:
-            path = os.path.join(temp, "with-labels.csv")
             main(
                 os.path.join(
                     os.path.dirname(os.path.realpath(__file__)),
                     "scores.csv"
                 ),
-                path
+                temp
             )
-            self.assertTrue("label" in pd.read_csv(path).columns)
+            self.assertTrue("label" in pd.read_csv(os.path.join(temp, "scores-labels.csv")).columns)

--- a/sr-data/src/tests/training.csv
+++ b/sr-data/src/tests/training.csv
@@ -1,0 +1,10 @@
+repo,releases,pulls,issues,branches,label
+arconia-io/arconia,5,0,9,1,NON
+amaseng/myinvois-open-sdk,0,5,0,6,NON
+ErayMert/microservice-log-tracing,0,0,0,1,SR
+aleixmorgadas/thin-ports-and-adapters,0,0,0,1,
+Tushar-Kapil/DSA-Notes,0,0,0,1,SR
+MEEPofFaith/hallucinogen,8,0,0,1,
+dee-coder01/BusBuddy,0,17,0,11,
+jon-mil-92/DisplayHotKeys,7,0,0,1,
+nilsreichardt/gad24-tests,0,13,0,10,


### PR DESCRIPTION
In this pull, I've implemented label preparation for Label Propagation Model, it's training, and saving to `out` file.

closes #102 
History:
- **feat(#102): labels**
- **feat(#102): labels for all**
- **feat(#102): ssl**
- **feat(#102): clean**
- **feat(#102): lpm, test case**
- **feat(#102): test training, docs**
- **chore: perms**

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enhancing the repository's testing and labeling functionality, including updates to workflows, new label handling scripts, and additional test cases for the new features.

### Detailed summary
- Updated `.github/workflows/nightly.yml` to change the testing schedule description.
- Added permissions for `issues` in the workflow.
- Introduced a new CSV file format in `sr-data/src/tests/training.csv`.
- Updated `cohere` version specification in `sr-data/pyproject.toml`.
- Added new tasks for `labels` and `label_propagation` in `pyproject.toml`.
- Created `sr-data/src/sr_data/steps/labels.py` for label handling.
- Implemented tests for label handling in `sr-data/src/tests/test_labels.py`.
- Added `label_propagation` model training in `sr-data/src/sr_data/steps/label_propagation.py`.
- Created tests for label propagation in `sr-data/src/tests/test_label_propagation.py`.
- Updated `justfile` with new commands for labels and label propagation.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->