### PR TITLE
feat(#63): ignore pulls from robots

### DIFF
--- a/.github/workflows/collect.yml
+++ b/.github/workflows/collect.yml
@@ -61,8 +61,7 @@ jobs:
           poetry install
           echo "${{ secrets.COLLECT_TOKEN_1 }}" >> "$PATS"
           just collect "collection" "${{ inputs.start }}" "${{ inputs.end }}" \
-            "${{ inputs.filename }}"
-          just pulls "$COLLECTION" "${{ secrets.GITHUB_TOKEN }}" "$PULLED"
+            "${{ inputs.filename }}" "${{ secrets.GITHUB_TOKEN }}"
           just filter "$PULLED" "$FILTER"
           just extract "$FILTER" "$EXTRACT"
           cp "$COLLECTION" collection

--- a/.github/workflows/collect.yml
+++ b/.github/workflows/collect.yml
@@ -38,6 +38,7 @@ permissions: write-all
 env:
   PATS: pats.txt
   COLLECTION: "${{ inputs.filename }}.csv"
+  PULLED: "${{ inputs.filename }}-with-pulls.csv"
   FILTER: "filter-${{ inputs.start }}-${{ inputs.end }}.csv"
   EXTRACT: "extract-${{ inputs.start }}-${{ inputs.end }}.csv"
 jobs:
@@ -59,13 +60,12 @@ jobs:
           just install
           poetry install
           echo "${{ secrets.COLLECT_TOKEN_1 }}" >> "$PATS"
-          mkdir -p collection
-          ghminer --start "${{ inputs.start }}" --end "${{ inputs.end }}" \
-            --query "stars:>10 language:java size:>=20 mirror:false template:false" \
-              --filename "${{ inputs.filename }}" --tokens "$PATS"
-          just filter "$COLLECTION" "$FILTER"
+          just collect "collection" "${{ inputs.start }}" "${{ inputs.end }}" \
+            "${{ inputs.filename }}" "${{ secrets.GITHUB_TOKEN }}"
+          just filter "$PULLED" "$FILTER"
           just extract "$FILTER" "$EXTRACT"
           cp "$COLLECTION" collection
+          cp "$PULLED" collection
           cp "$FILTER" collection
           cp "$EXTRACT" collection
       - uses: JamesIves/github-pages-deploy-action@v4.6.8

--- a/.github/workflows/collect.yml
+++ b/.github/workflows/collect.yml
@@ -61,7 +61,8 @@ jobs:
           poetry install
           echo "${{ secrets.COLLECT_TOKEN_1 }}" >> "$PATS"
           just collect "collection" "${{ inputs.start }}" "${{ inputs.end }}" \
-            "${{ inputs.filename }}" "${{ secrets.GITHUB_TOKEN }}"
+            "${{ inputs.filename }}"
+          just pulls "$COLLECTION" "${{ secrets.GITHUB_TOKEN }}" "$PULLED"
           just filter "$PULLED" "$FILTER"
           just extract "$FILTER" "$EXTRACT"
           cp "$COLLECTION" collection

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -30,6 +30,7 @@ permissions:
 env:
   HF_TESTING_TOKEN: ${{ secrets.HF_TESTING_TOKEN }}
   COHERE_TESTING_TOKEN: ${{ secrets.COHERE_TESTING_TOKEN }}
+  GH_TESTING_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 jobs:
   build:
     runs-on: ubuntu-24.04

--- a/ghminer.graphql
+++ b/ghminer.graphql
@@ -1,0 +1,44 @@
+query ($searchQuery: String!, $first: Int, $after: String) {
+  search(query: $searchQuery, type: REPOSITORY, first: $first, after: $after) {
+    repositoryCount
+    nodes {
+      ... on Repository {
+        nameWithOwner
+        defaultBranchRef {
+          name
+        }
+        createdAt
+        refs(refPrefix: "refs/heads/") {
+          totalCount
+        }
+        defaultBranchRef {
+          name
+          target {
+            repository {
+              object(expression: "HEAD:README.md") {
+                ... on Blob {
+                  text
+                }
+              }
+            }
+          }
+        }
+        releases(first:1) {
+          edges {
+            node {
+              id
+            }
+          }
+          totalCount
+        }
+        issues(states: [OPEN]) {
+          totalCount
+        }
+      }
+    }
+    pageInfo {
+      endCursor
+      hasNextPage
+    }
+  }
+}

--- a/ghminer.json
+++ b/ghminer.json
@@ -1,0 +1,7 @@
+{
+  "repo": "nameWithOwner",
+  "readme": "defaultBranchRef.target.repository.object.text",
+  "releases": "releases.totalCount",
+  "issues": "issues.totalCount",
+  "branches": "refs.totalCount"
+}

--- a/justfile
+++ b/justfile
@@ -59,10 +59,11 @@ clean:
   rm sr-data/experiment/* && rmdir sr-data/experiment
 
 # Collect repositories.
-collect dir start end out:
+collect dir start end out tenv:
   mkdir -p {{dir}}
   ghminer --query "stars:>10 language:java size:>=20 mirror:false template:false NOT android" \
     --start "{{start}}" --end "{{end}}" --tokens "$PATS" --filename "{{out}}"
+  just pulls "{{out}}.csv" "{{tenv}}" "{{out}}-with-pulls.csv"
 
 # Fetch pulls count for collected repos.
 pulls repos tenv out="experiment/with-pulls.csv":

--- a/justfile
+++ b/justfile
@@ -59,12 +59,10 @@ clean:
   rm sr-data/experiment/* && rmdir sr-data/experiment
 
 # Collect repositories.
-collect dir start end out tenv:
+collect dir start end out:
   mkdir -p {{dir}}
   ghminer --query "stars:>10 language:java size:>=20 mirror:false template:false NOT android" \
-    --start "{{start}}" --end "{{end}}" --tokens "$PATS" \
-    --filename "{{out}}" && mv repos.csv sr-data/experiment/repos.csv
-  just pulls "{{out}}" "{{tenv}}" "{{out}}-with-pulls.csv"
+    --start "{{start}}" --end "{{end}}" --tokens "$PATS" --filename "{{out}}"
 
 # Fetch pulls count for collected repos.
 pulls repos tenv out="experiment/with-pulls.csv":

--- a/justfile
+++ b/justfile
@@ -22,7 +22,7 @@
 
 # Install dependencies.
 install:
-  npm install -g ghminer@0.0.6
+  npm install -g ghminer@0.0.7
 
 # Full build.
 full tests="fast":
@@ -64,6 +64,10 @@ collect:
   ghminer --query "stars:>10 language:java size:>=20 mirror:false template:false NOT android" \
     --start "2019-01-01" --end "2024-05-01" --tokens "$PATS" \
     --filename "repos" && mv repos.csv sr-data/experiment/repos.csv
+
+# Fetch pulls count for collected repos.
+pulls repos out="experiment/with-pulls.csv":
+  cd sr-data && poetry poe pulls --repos {{repos}} --out {{out}}
 
 # Collect test repositories.
 test-collect:

--- a/justfile
+++ b/justfile
@@ -59,15 +59,16 @@ clean:
   rm sr-data/experiment/* && rmdir sr-data/experiment
 
 # Collect repositories.
-collect:
-  mkdir -p sr-data/experiment
+collect dir start end out tenv:
+  mkdir -p {{dir}}
   ghminer --query "stars:>10 language:java size:>=20 mirror:false template:false NOT android" \
-    --start "2019-01-01" --end "2024-05-01" --tokens "$PATS" \
-    --filename "repos" && mv repos.csv sr-data/experiment/repos.csv
+    --start "{{start}}" --end "{{end}}" --tokens "$PATS" \
+    --filename "{{out}}" && mv repos.csv sr-data/experiment/repos.csv
+  just pulls "{{out}}" "{{tenv}}" "{{out}}-with-pulls.csv"
 
 # Fetch pulls count for collected repos.
-pulls repos out="experiment/with-pulls.csv":
-  cd sr-data && poetry poe pulls --repos {{repos}} --out {{out}}
+pulls repos tenv out="experiment/with-pulls.csv":
+  cd sr-data && poetry poe pulls --repos {{repos}} --out {{out}} --tenv {{tenv}}
 
 # Collect test repositories.
 test-collect:

--- a/sr-data/pyproject.toml
+++ b/sr-data/pyproject.toml
@@ -85,8 +85,8 @@ script = "sr_data.steps.label_propagation:main(repos, out)"
 args = [{name = "repos"}, {name = "out"}]
 
 [tool.poe.tasks.pulls]
-script = "sr_data.steps.pulls:main(repos, out)"
-args = [{name = "repos"}, {name = "out"}]
+script = "sr_data.steps.pulls:main(repos, out, tenv)"
+args = [{name = "repos"}, {name = "out"}, {name = "tenv"}]
 
 [build-system]
 requires = ["setuptools", "wheel"]

--- a/sr-data/pyproject.toml
+++ b/sr-data/pyproject.toml
@@ -84,6 +84,10 @@ args = [{name = "repos"}, {name = "dir"}]
 script = "sr_data.steps.label_propagation:main(repos, out)"
 args = [{name = "repos"}, {name = "out"}]
 
+[tool.poe.tasks.pulls]
+script = "sr_data.steps.pulls:main(repos, out)"
+args = [{name = "repos"}, {name = "out"}]
+
 [build-system]
 requires = ["setuptools", "wheel"]
 build-backend = "setuptools.build_meta"

--- a/sr-data/src/sr_data/steps/pulls.py
+++ b/sr-data/src/sr_data/steps/pulls.py
@@ -1,0 +1,65 @@
+import pandas as pd
+import requests
+from loguru import logger
+
+
+def main(repos, out):
+    frame = pd.read_csv(repos)
+    for idx, row in frame.iterrows():
+        frame.at[idx, "pulls"] = pulls(row["repo"])
+    frame.to_csv(out, index=False)
+
+
+def pulls(repo):
+    logger.info(f"Fetching pulls for {repo}")
+    owner, name = repo.split("/")
+    count = 0
+    next = True
+    cursor = None
+    while next:
+        response = requests.post(
+            "https://api.github.com/graphql",
+            headers={
+                "Authorization": f"Bearer x",
+                "Content-Type": "application/json"
+            },
+            json={
+                "query": """
+                query ($owner: String!, $name: String!, $after: String) {
+                    repository(owner: $owner, name: $name) {
+                        pullRequests(first: 100, after: $after) {
+                            nodes {
+                                author {
+                                    login
+                                }
+                            }
+                            pageInfo {
+                                endCursor
+                                hasNextPage
+                            }
+                        }
+                    }
+                }            
+                """,
+                "variables": {
+                    "owner": owner,
+                    "name": name,
+                    "after": cursor
+                }
+            }
+        )
+        response_data = response.json()
+        if "errors" in response_data:
+            print(f"Error fetching data for {repo}: {response_data['errors']}")
+            break
+
+        pull_requests = response_data["data"]["repository"]["pullRequests"]
+        for pr in pull_requests["nodes"]:
+            if pr["author"]["login"] != "renovate[bot]":
+                count += 1
+
+        page_info = pull_requests["pageInfo"]
+        cursor = page_info["endCursor"]
+        next = page_info["hasNextPage"]
+    logger.info(f"Found {count} pulls")
+    return count

--- a/sr-data/src/tests/test_pulls.py
+++ b/sr-data/src/tests/test_pulls.py
@@ -1,0 +1,46 @@
+"""
+Test case for pulls.
+"""
+# The MIT License (MIT)
+#
+# Copyright (c) 2024 Aliaksei Bialiauski
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+import os
+import unittest
+from tempfile import TemporaryDirectory
+
+import pandas as pd
+import pytest
+from sr_data.steps.pulls import main
+
+class TestPulls(unittest.TestCase):
+
+    @pytest.mark.nightly
+    def test_finds_pulls(self):
+        with TemporaryDirectory() as temp:
+            path = os.path.join(temp, "with-pulls.csv")
+            main(
+                os.path.join(
+                    os.path.dirname(os.path.realpath(__file__)), "to-pull.csv"
+                ),
+                path,
+                "GITHUB_TESTING_TOKEN"
+            )
+            self.assertTrue("pulls" in pd.read_csv(path).columns)

--- a/sr-data/src/tests/test_pulls.py
+++ b/sr-data/src/tests/test_pulls.py
@@ -41,6 +41,6 @@ class TestPulls(unittest.TestCase):
                     os.path.dirname(os.path.realpath(__file__)), "to-pull.csv"
                 ),
                 path,
-                "GITHUB_TESTING_TOKEN"
+                "GH_TESTING_TOKEN"
             )
             self.assertTrue("pulls" in pd.read_csv(path).columns)

--- a/sr-data/src/tests/to-pull.csv
+++ b/sr-data/src/tests/to-pull.csv
@@ -1,0 +1,2 @@
+repo
+h1alexbel/h1alexbel


### PR DESCRIPTION
In this pull, I've implemented pulls detached fetch with bot ignorance logic.

closes #63 
History:
- **feat(#63): clean**
- **feat(#63): pulls**
- **feat(#63): pulls**
- **feat(#63): test case**
- **feat(#63): env**
- **feat(#63): PULLED**

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces enhancements for collecting pull request data from GitHub repositories, including updates to configuration files, new functionality in `pulls.py`, and tests for the new features.

### Detailed summary
- Added `to-pull.csv` for repository listing.
- Updated `ghminer.json` with new fields.
- Enhanced `.github/workflows/nightly.yml` for GitHub token usage.
- Modified `pyproject.toml` to include new task for pulls.
- Added GraphQL query in `ghminer.graphql` for repository data.
- Updated `justfile` with new commands for collecting and processing pull requests.
- Created `test_pulls.py` for testing pull request functionality.
- Implemented `pulls.py` to collect pull request counts from repositories.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->