### PR TITLE
fix(#108): gh token from environ

### DIFF
--- a/sr-data/src/tests/test_pulls.py
+++ b/sr-data/src/tests/test_pulls.py
@@ -41,6 +41,6 @@ class TestPulls(unittest.TestCase):
                     os.path.dirname(os.path.realpath(__file__)), "to-pull.csv"
                 ),
                 path,
-                "GH_TESTING_TOKEN"
+                os.environ["GH_TESTING_TOKEN"]
             )
             self.assertTrue("pulls" in pd.read_csv(path).columns)


### PR DESCRIPTION
closes #108 

<!-- start pr-codex -->

---

## PR-Codex overview
This PR modifies the way the `GH_TESTING_TOKEN` is accessed in the `test_pulls.py` file, ensuring it is retrieved from the environment variables instead of being hardcoded.

### Detailed summary
- Changed the hardcoded value `"GH_TESTING_TOKEN"` to `os.environ["GH_TESTING_TOKEN"]` in `test_pulls.py`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->