### PR TITLE
fix(#110): less verbose logging in embed step

### DIFF
--- a/sr-data/src/sr_data/steps/embed.py
+++ b/sr-data/src/sr_data/steps/embed.py
@@ -1,6 +1,8 @@
 """
 Generate embeddings.
 """
+from pathlib import Path
+
 # The MIT License (MIT)
 #
 # Copyright (c) 2024 Aliaksei Bialiauski
@@ -49,7 +51,9 @@ def main(repos, prefix, hf, cohere):
         words.replace("[", "").replace("]", "").replace("'", "")
     )
     for model, checkpoint in models.items():
-        logger.info(f"Generating {model} embeddings for {frame}...")
+        logger.info(
+            f"Generating {model} embeddings for {repos} ({len(frame)}r x {len(frame.columns)}c)"
+        )
         if model == "cohere":
             embed_cohere(cohere, frame, prefix)
         else:
@@ -57,7 +61,9 @@ def main(repos, prefix, hf, cohere):
             embeddings = pd.DataFrame(infer(frame["top"].tolist(), checkpoint, hf))
             embeddings.insert(0, 'repo', frame["repo"])
             embeddings.to_csv(f"{prefix}-{model}.csv", index=False)
-        logger.info(f"Generated embeddings {prefix}-{model}")
+        logger.info(
+            f"Generated embeddings saved to {prefix}-{model}.csv ({len(embeddings)}r x {len(embeddings.columns)}c)"
+        )
 
 
 def embed_cohere(key, texts, prefix):

--- a/sr-data/src/sr_data/steps/embed.py
+++ b/sr-data/src/sr_data/steps/embed.py
@@ -1,8 +1,6 @@
 """
 Generate embeddings.
 """
-from pathlib import Path
-
 # The MIT License (MIT)
 #
 # Copyright (c) 2024 Aliaksei Bialiauski


### PR DESCRIPTION
closes #110 
History:
- **feat(#110): more clean logging**
- **feat(#110): no path**


<!-- start pr-codex -->

---

## PR-Codex overview
This PR improves the logging messages in the `embed.py` file to provide more detailed information about the embedding generation process, including the dimensions of the data being processed.

### Detailed summary
- Updated the log message in the loop for each `model` to include the number of rows and columns of `frame` instead of just `frame`.
- Enhanced the log message after generating embeddings to specify the saved filename and dimensions of the `embeddings` DataFrame.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->