### PR TITLE
fix(#112): filter repos with pulls

### DIFF
--- a/.github/workflows/collect.yml
+++ b/.github/workflows/collect.yml
@@ -58,7 +58,7 @@ jobs:
           echo "${{ secrets.COLLECT_TOKEN_1 }}" >> "$PATS"
           just collect "collection/${{ inputs.out }}" "${{ inputs.start }}" \
             "${{ inputs.end }}" "repos" "${{ secrets.GITHUB_TOKEN }}"
-          just filter "repos.csv" "after-filter.csv"
+          just filter "repos-with-pulls.csv" "after-filter.csv"
           just extract "after-filter.csv" "after-extract.csv"
           cp "repos.csv" "collection/${{ inputs.out }}"
           cp "repos-with-pulls.csv" "collection/${{ inputs.out }}"


### PR DESCRIPTION
ref #112

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the workflow in the `.github/workflows/collect.yml` file to change the input file used for filtering from `repos.csv` to `repos-with-pulls.csv`. This likely reflects a change in the data source for further processing.

### Detailed summary
- Changed the input file for the `just filter` command from `repos.csv` to `repos-with-pulls.csv`.
- Updated the `cp` command to copy `repos-with-pulls.csv` instead of `repos.csv` to the output collection.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->