### PR TITLE
fix(#74): collect maven builds for each repo

### DIFF
--- a/.github/workflows/collect.yml
+++ b/.github/workflows/collect.yml
@@ -58,11 +58,15 @@ jobs:
           echo "${{ secrets.COLLECT_TOKEN_1 }}" >> "$PATS"
           just collect "collection/${{ inputs.out }}" "${{ inputs.start }}" \
             "${{ inputs.end }}" "repos" "${{ secrets.GITHUB_TOKEN }}"
-          just filter "repos-maven.csv" "after-filter.csv"
+          just filter "repos-with-pulls.csv" "after-filter.csv"
           just extract "after-filter.csv" "after-extract.csv"
-          cp "repos-maven.csv" "collection/${{ inputs.out }}"
+          just maven "after-extract.csv" "${{ secrets.GITHUB_TOKEN }}" \
+            "after-maven.csv"
+          cp "repos.csv" "collection/${{ inputs.out }}"
+          cp "repos-with-pulls.csv" "collection/${{ inputs.out }}"
           cp "after-filter.csv" "collection/${{ inputs.out }}"
           cp "after-extract.csv" "collection/${{ inputs.out }}"
+          cp "after-maven.csv" "collection/${{ inputs.out }}"
       - uses: JamesIves/github-pages-deploy-action@v4.6.8
         with:
           branch: collect

--- a/.github/workflows/collect.yml
+++ b/.github/workflows/collect.yml
@@ -58,10 +58,9 @@ jobs:
           echo "${{ secrets.COLLECT_TOKEN_1 }}" >> "$PATS"
           just collect "collection/${{ inputs.out }}" "${{ inputs.start }}" \
             "${{ inputs.end }}" "repos" "${{ secrets.GITHUB_TOKEN }}"
-          just filter "repos-with-pulls.csv" "after-filter.csv"
+          just filter "repos-maven.csv" "after-filter.csv"
           just extract "after-filter.csv" "after-extract.csv"
-          cp "repos.csv" "collection/${{ inputs.out }}"
-          cp "repos-with-pulls.csv" "collection/${{ inputs.out }}"
+          cp "repos-maven.csv" "collection/${{ inputs.out }}"
           cp "after-filter.csv" "collection/${{ inputs.out }}"
           cp "after-extract.csv" "collection/${{ inputs.out }}"
       - uses: JamesIves/github-pages-deploy-action@v4.6.8

--- a/ghminer.json
+++ b/ghminer.json
@@ -1,5 +1,6 @@
 {
   "repo": "nameWithOwner",
+  "branch": "defaultBranchRef.name",
   "readme": "defaultBranchRef.target.repository.object.text",
   "releases": "releases.totalCount",
   "issues": "issues.totalCount",

--- a/justfile
+++ b/justfile
@@ -66,6 +66,7 @@ collect dir start end out token:
   ghminer --query "stars:>10 language:java size:>=20 mirror:false template:false NOT android" \
     --start "{{start}}" --end "{{end}}" --tokens "$PATS" --filename "{{out}}"
   just pulls "../{{out}}.csv" "{{token}}" "../{{out}}-with-pulls.csv"
+  just maven "../{{out}}-with-pulls.csv" "{{token}}" "../{{out}}-maven.csv"
 
 # Fetch pulls count for collected repos.
 pulls repos token out="experiment/with-pulls.csv":

--- a/justfile
+++ b/justfile
@@ -66,14 +66,13 @@ collect dir start end out token:
   ghminer --query "stars:>10 language:java size:>=20 mirror:false template:false NOT android" \
     --start "{{start}}" --end "{{end}}" --tokens "$PATS" --filename "{{out}}"
   just pulls "../{{out}}.csv" "{{token}}" "../{{out}}-with-pulls.csv"
-  just maven "../{{out}}-with-pulls.csv" "{{token}}" "../{{out}}-maven.csv"
 
 # Fetch pulls count for collected repos.
 pulls repos token out="experiment/with-pulls.csv":
   cd sr-data && poetry poe pulls --repos "{{repos}}" --token "{{token}}" \
     --out "{{out}}"
 
-# Collect maven pom.xml files
+# Collect maven pom.xml files.
 maven repos token out="experiment/with-maven.csv":
   cd sr-data && poetry poe maven --repos "{{repos}}" --token "{{token}}" \
     --out "{{out}}"

--- a/justfile
+++ b/justfile
@@ -72,6 +72,11 @@ pulls repos token out="experiment/with-pulls.csv":
   cd sr-data && poetry poe pulls --repos "{{repos}}" --token "{{token}}" \
     --out "{{out}}"
 
+# Collect maven pom.xml files
+maven repos token out="experiment/with-maven.csv":
+  cd sr-data && poetry poe maven --repos "{{repos}}" --token "{{token}}" \
+    --out "{{out}}"
+
 # Collect test repositories.
 test-collect:
   mkdir -p sr-data/tmp

--- a/sr-data/pyproject.toml
+++ b/sr-data/pyproject.toml
@@ -88,6 +88,10 @@ args = [{name = "repos"}, {name = "out"}]
 script = "sr_data.steps.pulls:main(repos, out, token)"
 args = [{name = "repos"}, {name = "out"}, {name = "token"}]
 
+[tool.poe.tasks.maven]
+script = "sr_data.steps.maven:main(repos, out, token)"
+args = [{name = "repos"}, {name = "out"}, {name = "token"}]
+
 [build-system]
 requires = ["setuptools", "wheel"]
 build-backend = "setuptools.build_meta"

--- a/sr-data/src/sr_data/steps/maven.py
+++ b/sr-data/src/sr_data/steps/maven.py
@@ -30,6 +30,13 @@ from loguru import logger
 from requests import Response
 
 
+# @todo #74:45min Exclude repositories that don't have any maven projects.
+#  We need to exclude all repositories that don't contain any 'pom.xml' inside.
+#  Don't forget to create a unit test for this.
+# @todo #74:60min Parse 'build' JSON array of maven projects into most valuable
+#  information for embedding step. We should parse all maven projects from JSON
+#  array, extract some useful information from each, and merge into single
+#  input. For pom.xml parsing we can use XPATH, and XSLT for merging.
 def main(repos, out, token):
     frame = pd.read_csv(repos)
     for idx, row in frame.iterrows():

--- a/sr-data/src/sr_data/steps/maven.py
+++ b/sr-data/src/sr_data/steps/maven.py
@@ -1,3 +1,27 @@
+"""
+Collect maven information for each repo.
+"""
+# The MIT License (MIT)
+#
+# Copyright (c) 2024 Aliaksei Bialiauski
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
 import json
 
 import pandas as pd

--- a/sr-data/src/sr_data/steps/maven.py
+++ b/sr-data/src/sr_data/steps/maven.py
@@ -1,0 +1,40 @@
+import json
+
+import pandas as pd
+import requests
+from loguru import logger
+from requests import Response
+
+
+def main(repos, out, token):
+    frame = pd.read_csv(repos)
+    for idx, row in frame.iterrows():
+        frame.at[idx, "build"] = pom(row["repo"], row["branch"], token)
+    frame.to_csv(out, index=False)
+
+def pom(repo, branch, token):
+    files = request(token, repo)
+    poms = [file for file in files['tree'] if file['path'].endswith('pom.xml')]
+    build = []
+    for project in poms:
+        path = project["path"]
+        content = requests.get(
+            f"https://raw.githubusercontent.com/{repo}/refs/heads/{branch}/{path}"
+        ).text
+        build.append(
+            {
+                "path": path,
+                "content": content
+            }
+        )
+    logger.info(f"Found {len(build)} pom.xml files in {repo}")
+    return json.dumps(build)
+
+def request(token, repo) -> Response:
+    return requests.get(
+        f"https://api.github.com/repos/{repo}/git/trees/HEAD?recursive=1",
+        headers={
+            "Authorization": f"Bearer {token}",
+            "Content-Type": "application/json"
+        },
+    ).json()

--- a/sr-data/src/sr_data/steps/pulls.py
+++ b/sr-data/src/sr_data/steps/pulls.py
@@ -22,7 +22,6 @@ Collect pulls for each repo.
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
-
 import pandas as pd
 import requests
 from loguru import logger

--- a/sr-data/src/tests/test_maven.py
+++ b/sr-data/src/tests/test_maven.py
@@ -1,0 +1,48 @@
+"""
+Test case for maven.
+"""
+# The MIT License (MIT)
+#
+# Copyright (c) 2024 Aliaksei Bialiauski
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+import os
+import unittest
+from tempfile import TemporaryDirectory
+
+import pandas as pd
+import pytest
+from sr_data.steps.maven import main
+
+class TestMaven(unittest.TestCase):
+
+    @pytest.mark.nightly
+    def test_finds_pulls(self):
+        with TemporaryDirectory() as temp:
+            path = os.path.join(temp, "maven.csv")
+            main(
+                os.path.join(
+                    os.path.dirname(os.path.realpath(__file__)), "to-maven.csv"
+                ),
+                path,
+                os.environ["GH_TESTING_TOKEN"]
+            )
+            frame = pd.read_csv(path)
+            self.assertTrue("build" in frame.columns)
+            self.assertTrue("content" in frame.iloc[0]["build"])

--- a/sr-data/src/tests/to-maven.csv
+++ b/sr-data/src/tests/to-maven.csv
@@ -1,0 +1,2 @@
+repo,branch
+eo-cqrs/eo-kafka,master


### PR DESCRIPTION
In this pull, I've implemented collection for `pom.xml` files for each collected repo in `maven` receipe.

closes #74 
History:
- **feat(#74): maven.py**
- **feat(#74): license**
- **feat(#74): maven receie**
- **feat(#74): script**
- **feat(#74): defaultBranchRef**
- **feat(#74): puzzles**
- **feat(#74): empty line**
- **feat(#74): repos-maven**
- **feat(#74): test case**


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enhancing the functionality for collecting Maven information from repositories, including the addition of new scripts and tests to handle Maven `pom.xml` files and their integration into the project.

### Detailed summary
- Added `to-maven.csv` for repository and branch configuration.
- Introduced `maven` task in `justfile` for collecting Maven data.
- Updated `pyproject.toml` to include Maven task configuration.
- Modified `.github/workflows/collect.yml` to integrate Maven data collection.
- Created `test_maven.py` with a test case for Maven data collection.
- Developed `maven.py` with functions to collect and process Maven `pom.xml` files.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->