### PR TITLE
feat(#115): skip if languages contain other than 'en'

### DIFF
--- a/sr-data/src/sr_data/steps/filter.py
+++ b/sr-data/src/sr_data/steps/filter.py
@@ -25,8 +25,7 @@ Filter repositories.
 import markdown
 import pandas as pd
 from bs4 import BeautifulSoup, ParserRejectedMarkup
-from langdetect import DetectorFactory, LangDetectException
-from langdetect import detect
+from langdetect import DetectorFactory, LangDetectException, detect_langs
 from loguru import logger
 
 
@@ -80,7 +79,8 @@ def english(text):
     Skips non-english text.
     """
     try:
-        result = detect(text) == 'en'
+        langs = detect_langs(text)
+        result = len(langs) == 1 and langs[0].lang == "en"
     except (LangDetectException, TypeError):
         result = False
     return result


### PR DESCRIPTION
ref #115 

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the language detection functionality in the `english` function within the `filter.py` file. It replaces the single language detection method with a more robust approach that checks for multiple languages.

### Detailed summary
- Replaced `detect` with `detect_langs` from `langdetect`.
- Updated logic to check if only one language is detected and if it is English (`"en"`).

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->