### PR TITLE
feat(#117): skip repositories with empty maven projects

### DIFF
--- a/sr-data/src/sr_data/steps/maven.py
+++ b/sr-data/src/sr_data/steps/maven.py
@@ -41,6 +41,9 @@ def main(repos, out, token):
     frame = pd.read_csv(repos)
     for idx, row in frame.iterrows():
         frame.at[idx, "build"] = pom(row["repo"], row["branch"], token)
+    before = len(frame)
+    frame = frame[frame.build != "[]"]
+    logger.info(f"Skipped {before - len(frame)} repositories with 0 pom.xml files")
     frame.to_csv(out, index=False)
 
 def pom(repo, branch, token):

--- a/sr-data/src/tests/test_maven.py
+++ b/sr-data/src/tests/test_maven.py
@@ -30,10 +30,11 @@ import pandas as pd
 import pytest
 from sr_data.steps.maven import main
 
+
 class TestMaven(unittest.TestCase):
 
     @pytest.mark.nightly
-    def test_finds_pulls(self):
+    def test_finds_maven_projects(self):
         with TemporaryDirectory() as temp:
             path = os.path.join(temp, "maven.csv")
             main(
@@ -46,3 +47,18 @@ class TestMaven(unittest.TestCase):
             frame = pd.read_csv(path)
             self.assertTrue("build" in frame.columns)
             self.assertTrue("content" in frame.iloc[0]["build"])
+
+    @pytest.mark.nightly
+    def test_skips_repos_without_maven(self):
+        with TemporaryDirectory() as temp:
+            path = os.path.join(temp, "maven.csv")
+            main(
+                os.path.join(
+                    os.path.dirname(os.path.realpath(__file__)),
+                    "to-maven-skip.csv"
+                ),
+                path,
+                os.environ["GH_TESTING_TOKEN"]
+            )
+            frame = pd.read_csv(path)
+            self.assertTrue(len(frame) == 0)

--- a/sr-data/src/tests/to-maven-skip.csv
+++ b/sr-data/src/tests/to-maven-skip.csv
@@ -1,0 +1,2 @@
+repo,branch
+h1alexbel/h1alexbel,master


### PR DESCRIPTION
In this pull, I've updated `maven` step to skip repositories with 0 `pom.xml` files.

closes #117
History:
- **feat(#117): skip with 0 pom.xml**
- **feat(#117): typo, test case**
