### PR TITLE
feat(#118): merge pom.xml files into profile

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -48,7 +48,7 @@ jobs:
       - name: Build
         run: |
           just install
-          just full "nightly or deep or fast"
+          just full "nightly or fast"
   report-fail:
     name: Create issue on failure
     needs: build

--- a/_typos.toml
+++ b/_typos.toml
@@ -22,3 +22,6 @@
 [default]
 [files]
 extend-exclude = ["*.csv"]
+extend-ignore-identifiers-re = [
+    "packgs", # variable name
+]

--- a/_typos.toml
+++ b/_typos.toml
@@ -20,8 +20,8 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 [default]
-[files]
-extend-exclude = ["*.csv"]
 extend-ignore-identifiers-re = [
     "packgs", # variable name
 ]
+[files]
+extend-exclude = ["*.csv"]

--- a/sr-data/src/sr_data/steps/maven.py
+++ b/sr-data/src/sr_data/steps/maven.py
@@ -99,8 +99,11 @@ def merge(build, repo):
             logger.info(f"Skipping {path}, since it contains @project dependency")
         else:
             profile = {}
-            for packaging in root.findall(".//pom:packaging", namespaces):
+            packaging = root.find(".//pom:packaging", namespaces)
+            if packaging is not None:
                 packgs.append(packaging.text)
+            else:
+                packgs.append("jar")
             for plugin in root.findall(".//pom:plugin", namespaces):
                 print(ET.dump(plugin))
                 group = plugin.find("./pom:groupId", namespaces)

--- a/sr-data/src/tests/test_maven.py
+++ b/sr-data/src/tests/test_maven.py
@@ -28,7 +28,7 @@ from tempfile import TemporaryDirectory
 
 import pandas as pd
 import pytest
-from sr_data.steps.maven import main
+from sr_data.steps.maven import main, merge
 
 
 class TestMaven(unittest.TestCase):
@@ -62,3 +62,21 @@ class TestMaven(unittest.TestCase):
             )
             frame = pd.read_csv(path)
             self.assertTrue(len(frame) == 0)
+
+    @pytest.mark.fast
+    def test_merges_projects_in_one_profile(self):
+        merged = merge(
+            [
+                {
+                    "path": "core-spring/auto-configure/pom.xml",
+                    "content": "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<project xmlns=\"http://maven.apache.org/POM/4.0.0\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n\txsi:schemaLocation=\"http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd\">\n\t<modelVersion>4.0.0</modelVersion>\n\n\t<groupId>com.therealdanvega</groupId>\n\t<artifactId>auto-configure</artifactId>\n\t<version>0.0.1-SNAPSHOT</version>\n\t<packaging>jar</packaging>\n\n\t<name>auto-configure</name>\n\t<description>Spring Boot Auto Configure demo</description>\n\n\t<parent>\n\t\t<groupId>org.springframework.boot</groupId>\n\t\t<artifactId>spring-boot-starter-parent</artifactId>\n\t\t<version>1.3.0.BUILD-SNAPSHOT</version>\n\t\t<relativePath/> <!-- lookup parent from repository -->\n\t</parent>\n\n\t<properties>\n\t\t<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>\n\t\t<java.version>1.8</java.version>\n\t</properties>\n\n\t<dependencies>\n\t\t<dependency>\n\t\t\t<groupId>org.springframework.boot</groupId>\n\t\t\t<artifactId>spring-boot-starter-web</artifactId>\n\t\t</dependency>\n\t\t\n\t\t<dependency>\n\t\t\t<groupId>org.springframework.boot</groupId>\n\t\t\t<artifactId>spring-boot-starter-test</artifactId>\n\t\t\t<scope>test</scope>\n\t\t</dependency>\n\t</dependencies>\n\t\n\t<build>\n\t\t<plugins>\n\t\t\t<plugin>\n\t\t\t\t<groupId>org.springframework.boot</groupId>\n\t\t\t\t<artifactId>spring-boot-maven-plugin</artifactId>\n\t\t\t</plugin>\n\t\t</plugins>\n\t</build>\n\t\n\t<repositories>\n\t\t<repository>\n\t\t\t<id>spring-snapshots</id>\n\t\t\t<name>Spring Snapshots</name>\n\t\t\t<url>https://repo.spring.io/snapshot</url>\n\t\t\t<snapshots>\n\t\t\t\t<enabled>true</enabled>\n\t\t\t</snapshots>\n\t\t</repository>\n\t\t<repository>\n\t\t\t<id>spring-milestones</id>\n\t\t\t<name>Spring Milestones</name>\n\t\t\t<url>https://repo.spring.io/milestone</url>\n\t\t\t<snapshots>\n\t\t\t\t<enabled>false</enabled>\n\t\t\t</snapshots>\n\t\t</repository>\n\t</repositories>\n\t<pluginRepositories>\n\t\t<pluginRepository>\n\t\t\t<id>spring-snapshots</id>\n\t\t\t<name>Spring Snapshots</name>\n\t\t\t<url>https://repo.spring.io/snapshot</url>\n\t\t\t<snapshots>\n\t\t\t\t<enabled>true</enabled>\n\t\t\t</snapshots>\n\t\t</pluginRepository>\n\t\t<pluginRepository>\n\t\t\t<id>spring-milestones</id>\n\t\t\t<name>Spring Milestones</name>\n\t\t\t<url>https://repo.spring.io/milestone</url>\n\t\t\t<snapshots>\n\t\t\t\t<enabled>false</enabled>\n\t\t\t</snapshots>\n\t\t</pluginRepository>\n\t</pluginRepositories>\n\n</project>\n"
+                },
+                {
+                    "path": "core-spring/beans/pom.xml",
+                    "content": "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<project xmlns=\"http://maven.apache.org/POM/4.0.0\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n\txsi:schemaLocation=\"http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd\">\n\t<modelVersion>4.0.0</modelVersion>\n\n\t<groupId>com.therealdanvega</groupId>\n\t<artifactId>sbeans</artifactId>\n\t<version>0.0.1-SNAPSHOT</version>\n\t<packaging>jar</packaging>\n\n\t<name>SpringBeans</name>\n\t<description>Spring Beans Demo</description>\n\n\t<parent>\n\t\t<groupId>org.springframework.boot</groupId>\n\t\t<artifactId>spring-boot-starter-parent</artifactId>\n\t\t<version>1.3.0.BUILD-SNAPSHOT</version>\n\t\t<relativePath/> <!-- lookup parent from repository -->\n\t</parent>\n\n\t<properties>\n\t\t<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>\n\t\t<java.version>1.8</java.version>\n\t</properties>\n\n\t<dependencies>\n\t\t<dependency>\n\t\t\t<groupId>org.springframework.boot</groupId>\n\t\t\t<artifactId>spring-boot-starter-web</artifactId>\n\t\t</dependency>\n\t\t\n\t\t<dependency>\n\t\t\t<groupId>org.springframework.boot</groupId>\n\t\t\t<artifactId>spring-boot-starter-test</artifactId>\n\t\t\t<scope>test</scope>\n\t\t</dependency>\n\t</dependencies>\n\t\n\t<build>\n\t\t<plugins>\n\t\t\t<plugin>\n\t\t\t\t<groupId>org.springframework.boot</groupId>\n\t\t\t\t<artifactId>spring-boot-maven-plugin</artifactId>\n\t\t\t</plugin>\n\t\t</plugins>\n\t</build>\n\t\n\t<repositories>\n\t\t<repository>\n\t\t\t<id>spring-snapshots</id>\n\t\t\t<name>Spring Snapshots</name>\n\t\t\t<url>https://repo.spring.io/snapshot</url>\n\t\t\t<snapshots>\n\t\t\t\t<enabled>true</enabled>\n\t\t\t</snapshots>\n\t\t</repository>\n\t\t<repository>\n\t\t\t<id>spring-milestones</id>\n\t\t\t<name>Spring Milestones</name>\n\t\t\t<url>https://repo.spring.io/milestone</url>\n\t\t\t<snapshots>\n\t\t\t\t<enabled>false</enabled>\n\t\t\t</snapshots>\n\t\t</repository>\n\t</repositories>\n\t<pluginRepositories>\n\t\t<pluginRepository>\n\t\t\t<id>spring-snapshots</id>\n\t\t\t<name>Spring Snapshots</name>\n\t\t\t<url>https://repo.spring.io/snapshot</url>\n\t\t\t<snapshots>\n\t\t\t\t<enabled>true</enabled>\n\t\t\t</snapshots>\n\t\t</pluginRepository>\n\t\t<pluginRepository>\n\t\t\t<id>spring-milestones</id>\n\t\t\t<name>Spring Milestones</name>\n\t\t\t<url>https://repo.spring.io/milestone</url>\n\t\t\t<snapshots>\n\t\t\t\t<enabled>false</enabled>\n\t\t\t</snapshots>\n\t\t</pluginRepository>\n\t</pluginRepositories>\n\n</project>\n"
+                },
+            ],
+            "foo/bar"
+        )
+        self.assertEqual(merged["projects"], 2)
+        self.assertEqual(merged["plugins"], ["org.springframework.boot:spring-boot-maven-plugin"])

--- a/sr-data/src/tests/test_maven.py
+++ b/sr-data/src/tests/test_maven.py
@@ -45,8 +45,14 @@ class TestMaven(unittest.TestCase):
                 os.environ["GH_TESTING_TOKEN"]
             )
             frame = pd.read_csv(path)
-            self.assertTrue("build" in frame.columns)
-            self.assertTrue("content" in frame.iloc[0]["build"])
+            self.assertEqual(
+                frame.iloc[0]["plugins"],
+                "[com.github.volodya-lombrozo:jtcop-maven-plugin,maven-surefire-plugin,org.apache.maven.plugins:maven-checkstyle-plugin,org.apache.maven.plugins:maven-compiler-plugin,org.apache.maven.plugins:maven-gpg-plugin,org.apache.maven.plugins:maven-invoker-plugin,org.apache.maven.plugins:maven-javadoc-plugin,org.apache.maven.plugins:maven-source-plugin,org.apache.maven.plugins:maven-verifier-plugin,org.jacoco:jacoco-maven-plugin,org.sonatype.plugins:nexus-staging-maven-plugin,ru.l3r8y:sa-tan]"
+            )
+            self.assertEqual(frame.iloc[0]["projects"], 1.0)
+            self.assertEqual(frame.iloc[0]["pwars"], 0.0)
+            self.assertEqual(frame.iloc[0]["pjars"], 0.0)
+            self.assertEqual(frame.iloc[0]["ppoms"], 0.0)
 
     @pytest.mark.nightly
     def test_skips_repos_without_maven(self):

--- a/sr-data/src/tests/test_maven.py
+++ b/sr-data/src/tests/test_maven.py
@@ -80,3 +80,6 @@ class TestMaven(unittest.TestCase):
         )
         self.assertEqual(merged["projects"], 2)
         self.assertEqual(merged["plugins"], ["org.springframework.boot:spring-boot-maven-plugin"])
+        self.assertEqual(merged["packages"]["jars"], 2)
+        self.assertEqual(merged["packages"]["wars"], 0)
+        self.assertEqual(merged["packages"]["poms"], 0)

--- a/sr-data/src/tests/test_maven.py
+++ b/sr-data/src/tests/test_maven.py
@@ -51,7 +51,7 @@ class TestMaven(unittest.TestCase):
             )
             self.assertEqual(frame.iloc[0]["projects"], 1.0)
             self.assertEqual(frame.iloc[0]["pwars"], 0.0)
-            self.assertEqual(frame.iloc[0]["pjars"], 0.0)
+            self.assertEqual(frame.iloc[0]["pjars"], 1.0)
             self.assertEqual(frame.iloc[0]["ppoms"], 0.0)
 
     @pytest.mark.nightly


### PR DESCRIPTION
In this pull, I've implemented merging all pom.xml files into single profile in `maven` step. The following columns were added: `projects`, `plugins`, `pwars`, `pjars`, `ppoms`.

closes #118
History:
- **feat(#118): test case**
- **feat(#118): merge**
- **feat(#118): nightly only**
- **feat(#118): jar is default**
- **feat(#118): puzzles, pretty XML**

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces enhancements to the `maven.py` script for better handling and merging of Maven project data, updates the CI workflow, and improves testing functionalities. It includes changes to variable handling, XML parsing, and adds new test cases.

### Detailed summary
- Added `extend-ignore-identifiers-re` in `_typos.toml`.
- Updated CI workflow in `.github/workflows/nightly.yml` to remove "deep" from command.
- Introduced XML parsing with `xml.etree.ElementTree` in `sr_data/src/sr_data/steps/maven.py`.
- Enhanced `main` function to handle Maven project profiles.
- Updated `pom` function to return merged project data.
- Added `merge` function to consolidate Maven project information.
- Introduced new test case for merging projects in `sr-data/src/tests/test_maven.py`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->