### PR TITLE
feat(#60): docker experiment

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,40 @@
+# The MIT License (MIT)
+#
+# Copyright (c) 2024 Aliaksei Bialiauski
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+---
+name: docker
+concurrency:
+  group: docker-${{ github.ref }}
+  cancel-in-progress: true
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+jobs:
+  docker:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+      - run: docker build . -t experiment
+      - run: docker run --rm experiment install

--- a/.rultor.yml
+++ b/.rultor.yml
@@ -24,28 +24,26 @@ architect:
   - h1alexbel
 docker:
   image: yegor256/rultor-image:1.23.1
+assets:
+  docker-password: h1alexbel/home#assets/docker-password
 install: |
   rustup update
   cargo install --version 1.30.1 just
-  python3 -m pip install --upgrade pip
-  pip3 install -U pip setuptools
-  sudo apt-get -y update
-  sudo apt-get -y install python3.10-venv
-  pip install --user pipx
-  export PATH=/home/r/.local/bin
-  pipx ensurepath
-  pipx install poetry==1.8.3
-  just versions
+  curl -sSL https://install.python-poetry.org | python3 - && rm -rf /var/lib/apt/lists/*
+  export PATH="$HOME/.local/bin:$PATH
 merge:
   script: |
-    just full
-# @todo #5:30min Create release script for whole project.
-#  Let's create a one for the whole project, including all modules.
-#  We should release all the modules: `sr-data|train|detector` to the PyPI. By
-#  doing so, we should ensure that `sr-detector` is available to be installed
-#  as standalone CLI tool. For `sr-data` and `sr-train` we should output some
-#  prominent files like CSV files and model files. Let's skip sr-paper for now.
+    just install
+    poetry install --no-root
+    just test "deep or fast"
+    just check
 release:
   script: |-
-    echo "there is no #release script at the moment"
-    exit 0
+    [[ "${tag}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] || exit -1
+    repo=h1alexbel/sr-detection
+    sed -i -e "s/^0.0.0/${tag}/" Dockerfile
+    sudo docker build "$(pwd)" --tag "${repo}:${tag}"
+    sudo docker tag "${repo}:${tag}" "${repo}:latest"
+    cat ../docker-password | sudo docker login --password-stdin --username h1alexbel
+    sudo docker push "${repo}:${tag}"
+    sudo docker push "${repo}:latest"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,61 @@
+# The MIT License (MIT)
+#
+# Copyright (c) 2024 Aliaksei Bialiauski
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+FROM python:3.12-slim
+
+# Poetry environment variables.
+ENV POETRY_VERSION=1.8.0 \
+    POETRY_VIRTUALENVS_CREATE=false \
+    PIP_NO_CACHE_DIR=off \
+    PIP_DISABLE_PIP_VERSION_CHECK=on
+
+# Python3.
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends curl build-essential && \
+    curl -sSL https://install.python-poetry.org | python3 - && \
+    rm -rf /var/lib/apt/lists/*
+
+# PATH.
+ENV PATH="/root/.local/bin:${HOME}/.cargo/bin:${PATH}"
+
+# NodeJS
+RUN rm -rf /usr/lib/node_modules \
+  && curl -sL https://deb.nodesource.com/setup_18.x -o /tmp/nodesource_setup.sh \
+  && bash /tmp/nodesource_setup.sh \
+  && apt-get -y install nodejs --no-install-recommends \
+  && bash -c 'node --version' \
+  && bash -c 'npm --version'
+
+# Rust, Cargo, Just.
+ENV PATH="${PATH}:${HOME}/.cargo/bin"
+RUN curl https://sh.rustup.rs -sSf | bash -s -- -y \
+  && echo 'export PATH=${PATH}:${HOME}/.cargo/bin' >> /root/.profile \
+  && ${HOME}/.cargo/bin/rustup toolchain install stable \
+  && bash -c '"${HOME}/.cargo/bin/cargo" --version' \
+  && bash -c '"${HOME}/.cargo/bin/cargo" install just@1.30.1'
+
+COPY sr-data ./sr-data
+COPY pyproject.toml justfile ./
+RUN bash -c '"${HOME}/.cargo/bin/just" install'
+RUN poetry install --no-root
+COPY . .
+ENTRYPOINT ["/root/.cargo/bin/just"]

--- a/README.md
+++ b/README.md
@@ -25,6 +25,12 @@ collected metadata about GitHub repositories.
 
 ## Experiment's steps
 
+To run the entire experiment in Docker:
+
+```bash
+docker run --rm -v "$(pwd)/output:/experiment" h1alexbel/sr-detection experiment
+```
+
 ### Metadata collection
 
 We collect two-fold metadata for each GitHub repository: numerical, and


### PR DESCRIPTION
In this pull, I've created `Dockerfile` with required infrastructure for experiments in Docker

ref #60 
History:
- **feat(#60): docker**
- **fix(#60, #7): release to dockerhub**


<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces Docker support for the experiment, adds a license to several files, and updates the `Dockerfile` to include necessary dependencies for running the project with `Poetry`, `NodeJS`, and `Rust`. It also refines the release process.

### Detailed summary
- Added Docker command to `README.md` for running the experiment.
- Included MIT License in `.github/workflows/docker.yml` and `Dockerfile`.
- Updated `Dockerfile` to install `Poetry`, `NodeJS`, and `Rust`.
- Modified `.rultor.yml` to streamline installation and release processes.
- Changed release script to handle version tags and Docker image management.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->