### PR TITLE
feat(#125): skip None artifact in maven step

### DIFF
--- a/sr-data/src/sr_data/steps/maven.py
+++ b/sr-data/src/sr_data/steps/maven.py
@@ -118,7 +118,7 @@ def merge(build, repo):
                 artifact = plugin.find("./pom:artifactId", namespaces)
                 if group is not None:
                     plugins.append(f"{group.text}:{artifact.text}")
-                else:
+                elif artifact is not None:
                     plugins.append(artifact.text)
             good.append(profile)
     used = len(good)

--- a/sr-data/src/tests/test_maven.py
+++ b/sr-data/src/tests/test_maven.py
@@ -69,6 +69,25 @@ class TestMaven(unittest.TestCase):
             frame = pd.read_csv(path)
             self.assertTrue(len(frame) == 0)
 
+    @pytest.mark.nightly
+    def test_skips_plugin_without_artifact(self):
+        with TemporaryDirectory() as temp:
+            path = os.path.join(temp, "maven.csv")
+            main(
+                os.path.join(
+                    os.path.dirname(os.path.realpath(__file__)),
+                    "to-maven-without-artifact.csv"
+                ),
+                path,
+                os.environ["GH_TESTING_TOKEN"]
+            )
+            frame = pd.read_csv(path)
+            self.assertEqual(
+                frame.iloc[0]["plugins"],
+                "[org.jetbrains.kotlin:kotlin-maven-plugin,org.springframework.boot:spring-boot-maven-plugin]"
+            )
+
+
     @pytest.mark.fast
     def test_merges_projects_in_one_profile(self):
         merged = merge(

--- a/sr-data/src/tests/to-maven-without-artifact.csv
+++ b/sr-data/src/tests/to-maven-without-artifact.csv
@@ -1,0 +1,2 @@
+repo,branch
+habuma/spring-ai-examples,main


### PR DESCRIPTION
closes #125 

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces a new CSV file for testing, modifies the logic in the `maven.py` file to handle cases where an artifact may not be present, and adds a new test case in `test_maven.py` to verify the behavior when a plugin lacks an artifact.

### Detailed summary
- Added `to-maven-without-artifact.csv` file with repository and branch information.
- Updated logic in `maven.py` to check for `artifact` only if `group` is `None`.
- Introduced `test_skips_plugin_without_artifact` in `test_maven.py` to test behavior when no artifact is provided.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->