### PR TITLE
feat(#138): swc step

### DIFF
--- a/.github/workflows/collect.yml
+++ b/.github/workflows/collect.yml
@@ -59,16 +59,19 @@ jobs:
             just install
             poetry install
             just collect "collection/${{ inputs.out }}" "${{ inputs.start }}" \
-              "${{ inputs.end }}" "repos" "$TOKEN"
-            just filter "repos-with-pulls.csv" "after-filter.csv"
-            just extract "after-filter.csv" "after-extract.csv"
-            just maven "after-extract.csv" "$TOKEN" \
-              "after-maven.csv"
+              "${{ inputs.end }}" "repos"
+            just pulls "../repos.csv" "$TOKEN" "../repos-with-pulls.csv"
+            just filter "../repos-with-pulls.csv" "../after-filter.csv"
+            just swc "../after-filter.csv" "../after-swc.csv"
+            just extract "../after-swc.csv" "../after-extract.csv"
+            just maven "../after-extract.csv" "$TOKEN" \
+              "../after-maven.csv"
           } 2>&1 | tee -a collect.log
           sed -i "s|$TOKEN|REDACTED|g" collect.log
           cp "repos.csv" "collection/${{ inputs.out }}"
           cp "repos-with-pulls.csv" "collection/${{ inputs.out }}"
           cp "after-filter.csv" "collection/${{ inputs.out }}"
+          cp "after-swc.csv" "collection/${{ inputs.out }}"
           cp "after-extract.csv" "collection/${{ inputs.out }}"
           cp "after-maven.csv" "collection/${{ inputs.out }}"
           cp "collect.log" collection/${{ inputs.out }}

--- a/justfile
+++ b/justfile
@@ -61,11 +61,10 @@ clean:
   rm sr-data/experiment/* && rmdir sr-data/experiment
 
 # Collect repositories.
-collect dir start end out token:
+collect dir start end out:
   mkdir -p {{dir}}
   ghminer --query "stars:>10 language:java size:>=20 mirror:false template:false NOT android" \
     --start "{{start}}" --end "{{end}}" --tokens "$PATS" --filename "{{out}}"
-  just pulls "../{{out}}.csv" "{{token}}" "../{{out}}-with-pulls.csv"
 
 # Fetch pulls count for collected repos.
 pulls repos token out="experiment/with-pulls.csv":
@@ -74,8 +73,8 @@ pulls repos token out="experiment/with-pulls.csv":
 
 # Collect maven pom.xml files.
 maven repos token out="experiment/with-maven.csv":
-  cd sr-data && poetry poe maven --repos "../{{repos}}" --token "{{token}}" \
-    --out "../{{out}}"
+  cd sr-data && poetry poe maven --repos "{{repos}}" --token "{{token}}" \
+    --out "{{out}}"
 
 # Collect test repositories.
 test-collect:
@@ -86,16 +85,16 @@ test-collect:
 
 # Filter collected repositories.
 filter repos out="experiment/after-filter.csv":
-  cd sr-data && poetry poe filter --repos "../{{repos}}" --out "../{{out}}"
+  cd sr-data && poetry poe filter --repos "{{repos}}" --out "{{out}}"
 
 # Extract headings from README files.
 extract repos out="experiment/after-extract.csv":
-  cd sr-data && poetry poe extract --repos "../{{repos}}" --out "../{{out}}"
+  cd sr-data && poetry poe extract --repos "{{repos}}" --out "{{out}}"
 
 # Special words count.
 swc repos out="experiment/after-swc.csv" config="resources/swc-words.txt":
-  cd sr-data && poetry poe swc --repos {{repos}} --out {{out}} \
-    --config {{config}}
+  cd sr-data && poetry poe swc --repos "{{repos}}" --out "{{out}}" \
+    --config "{{config}}"
 
 # Create embeddings.
 embed repos prefix="experiment/embeddings":

--- a/justfile
+++ b/justfile
@@ -92,6 +92,11 @@ filter repos out="experiment/after-filter.csv":
 extract repos out="experiment/after-extract.csv":
   cd sr-data && poetry poe extract --repos "../{{repos}}" --out "../{{out}}"
 
+# Special words count.
+swc repos out="experiment/after-swc.csv" config="resources/swc-words.txt":
+  cd sr-data && poetry poe swc --repos {{repos}} --out {{out}} \
+    --config {{config}}
+
 # Create embeddings.
 embed repos prefix="experiment/embeddings":
   cd sr-data && poetry poe embed --repos {{repos}} --prefix {{prefix}} \

--- a/sr-data/pyproject.toml
+++ b/sr-data/pyproject.toml
@@ -93,7 +93,7 @@ script = "sr_data.steps.maven:main(repos, out, token)"
 args = [{name = "repos"}, {name = "out"}, {name = "token"}]
 
 [tool.poe.tasks.swc]
-script = "sr_data.steps.special_words_count:main(repos, out, config)"
+script = "sr_data.steps.swc:main(repos, out, config)"
 args = [{name = "repos"}, {name = "out"}, {name = "config"}]
 
 [build-system]

--- a/sr-data/pyproject.toml
+++ b/sr-data/pyproject.toml
@@ -92,6 +92,10 @@ args = [{name = "repos"}, {name = "out"}, {name = "token"}]
 script = "sr_data.steps.maven:main(repos, out, token)"
 args = [{name = "repos"}, {name = "out"}, {name = "token"}]
 
+[tool.poe.tasks.swc]
+script = "sr_data.steps.special_words_count:main(repos, out, config)"
+args = [{name = "repos"}, {name = "out"}, {name = "config"}]
+
 [build-system]
 requires = ["setuptools", "wheel"]
 build-backend = "setuptools.build_meta"

--- a/sr-data/resources/swc-words.txt
+++ b/sr-data/resources/swc-words.txt
@@ -1,0 +1,1 @@
+example

--- a/sr-data/resources/swc-words.txt
+++ b/sr-data/resources/swc-words.txt
@@ -1,1 +1,3 @@
 example
+sample
+demonstration

--- a/sr-data/src/sr_data/steps/special_words_count.py
+++ b/sr-data/src/sr_data/steps/special_words_count.py
@@ -1,6 +1,8 @@
 """
 Extract README headings (#).
 """
+import re
+
 # The MIT License (MIT)
 #
 # Copyright (c) 2024 Aliaksei Bialiauski
@@ -41,6 +43,10 @@ def main(repos, out, config):
 
 
 def word_count(repo, word, txt) -> int:
-    count: int = 0
-    logger.info(f"Repo {repo} contains {count} '{word}' words")
-    return count
+    logger.debug(f"Counting '{word}' in {repo}...")
+    first = word[0]
+    pattern = fr"\[{first.upper()}-{first.lower()}]{word[1:]}"
+    matches = len(re.findall(pattern, txt))
+    logger.debug(f"Found {matches} matches with {pattern}")
+    logger.info(f"Repo {repo} contains {matches} '{word}' words")
+    return matches

--- a/sr-data/src/sr_data/steps/special_words_count.py
+++ b/sr-data/src/sr_data/steps/special_words_count.py
@@ -1,0 +1,45 @@
+"""
+Extract README headings (#).
+"""
+# The MIT License (MIT)
+#
+# Copyright (c) 2024 Aliaksei Bialiauski
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+import pandas as pd
+from loguru import logger
+
+
+def main(repos, out, config):
+    frame = pd.read_csv(repos)
+    with open(config) as file:
+        for line in file:
+            word = line.strip()
+            stat = f"{word}_wc"
+            frame[stat] = frame.apply(
+                lambda row: word_count(row["repo"], word, row["readme"]),
+                axis=1
+            )
+    frame.to_csv(out, index=False)
+    logger.info(f"Saved output to {out}")
+
+
+def word_count(repo, word, txt) -> int:
+    logger.info(f"Counting special words '{word}' in {repo}")
+    return 0

--- a/sr-data/src/sr_data/steps/special_words_count.py
+++ b/sr-data/src/sr_data/steps/special_words_count.py
@@ -1,8 +1,6 @@
 """
-Extract README headings (#).
+Count special words in README.
 """
-import re
-
 # The MIT License (MIT)
 #
 # Copyright (c) 2024 Aliaksei Bialiauski
@@ -24,6 +22,7 @@ import re
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
+import re
 import pandas as pd
 from loguru import logger
 

--- a/sr-data/src/sr_data/steps/special_words_count.py
+++ b/sr-data/src/sr_data/steps/special_words_count.py
@@ -23,6 +23,7 @@ Count special words in README.
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 import re
+
 import pandas as pd
 from loguru import logger
 

--- a/sr-data/src/sr_data/steps/special_words_count.py
+++ b/sr-data/src/sr_data/steps/special_words_count.py
@@ -43,10 +43,9 @@ def main(repos, out, config):
 
 
 def word_count(repo, word, txt) -> int:
-    logger.debug(f"Counting '{word}' in {repo}...")
     first = word[0]
-    pattern = fr"\[{first.upper()}-{first.lower()}]{word[1:]}"
-    matches = len(re.findall(pattern, txt))
-    logger.debug(f"Found {matches} matches with {pattern}")
-    logger.info(f"Repo {repo} contains {matches} '{word}' words")
+    regex = fr"[{first.upper()}-{first.lower()}]{word[1:]}"
+    pattern = re.compile(regex)
+    matches = len(pattern.findall(txt))
+    logger.info(f"Repo {repo} contains {matches} '{regex}' words")
     return matches

--- a/sr-data/src/sr_data/steps/special_words_count.py
+++ b/sr-data/src/sr_data/steps/special_words_count.py
@@ -41,5 +41,6 @@ def main(repos, out, config):
 
 
 def word_count(repo, word, txt) -> int:
-    logger.info(f"Counting special words '{word}' in {repo}")
-    return 0
+    count: int = 0
+    logger.info(f"Repo {repo} contains {count} '{word}' words")
+    return count

--- a/sr-data/src/sr_data/steps/swc.py
+++ b/sr-data/src/sr_data/steps/swc.py
@@ -1,5 +1,5 @@
 """
-Count special words in README.
+Count of special words in README.
 """
 # The MIT License (MIT)
 #

--- a/sr-data/src/tests/test_swc.py
+++ b/sr-data/src/tests/test_swc.py
@@ -49,11 +49,11 @@ class TestSwc(unittest.TestCase):
     def test_saves_counts(self):
         with TemporaryDirectory() as temp:
             path = os.path.join(temp, "swc.csv")
-            config = "swc-config.txt"
-            with open(os.path.join(temp, config)) as f:
+            config = os.path.join(temp, "swc-config.txt")
+            with open(config, "w") as f:
                 f.write("example\n")
                 f.write("sample\n")
-                f.write("demonstration\n")
+                f.write("demo\n")
             main(
                 os.path.join(
                     os.path.dirname(os.path.realpath(__file__)),
@@ -63,6 +63,6 @@ class TestSwc(unittest.TestCase):
                 config
             )
             out = pd.read_csv(path)
-            self.assertEqual(out.iloc[0]["example_wc"], 10)
-            self.assertEqual(out.iloc[0]["sample_wc"], 10)
-            self.assertEqual(out.iloc[0]["demonstration_wc"], 10)
+            self.assertEqual(out.iloc[0]["example_wc"], 4)
+            self.assertEqual(out.iloc[0]["sample_wc"], 0)
+            self.assertEqual(out.iloc[0]["demo_wc"], 14)

--- a/sr-data/src/tests/test_swc.py
+++ b/sr-data/src/tests/test_swc.py
@@ -1,0 +1,42 @@
+"""
+Tests for special words count in README.
+"""
+# The MIT License (MIT)
+#
+# Copyright (c) 2024 Aliaksei Bialiauski
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+import unittest
+
+import pytest
+from sr_data.steps.swc import word_count
+
+class TestSwc(unittest.TestCase):
+
+    @pytest.mark.fast
+    def test_counts_example_word(self):
+        count = word_count(
+            "foo/bar", "example", "This is test Example. Example is good, examples are good. Examples are awesome"
+        )
+        expected = 4
+        self.assertEqual(
+            count,
+            expected,
+            f"Found 'example' word count: {count} does not matches with expected: {expected}"
+        )

--- a/sr-data/src/tests/test_swc.py
+++ b/sr-data/src/tests/test_swc.py
@@ -22,10 +22,14 @@ Tests for special words count in README.
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
+import os.path
 import unittest
+from tempfile import TemporaryDirectory, TemporaryFile
 
+import pandas as pd
 import pytest
-from sr_data.steps.swc import word_count
+from sr_data.steps.swc import word_count, main
+
 
 class TestSwc(unittest.TestCase):
 
@@ -40,3 +44,25 @@ class TestSwc(unittest.TestCase):
             expected,
             f"Found 'example' word count: {count} does not matches with expected: {expected}"
         )
+
+    @pytest.mark.fast
+    def test_saves_counts(self):
+        with TemporaryDirectory() as temp:
+            path = os.path.join(temp, "swc.csv")
+            config = "swc-config.txt"
+            with open(os.path.join(temp, config)) as f:
+                f.write("example\n")
+                f.write("sample\n")
+                f.write("demonstration\n")
+            main(
+                os.path.join(
+                    os.path.dirname(os.path.realpath(__file__)),
+                    "to-swc.csv"
+                ),
+                path,
+                config
+            )
+            out = pd.read_csv(path)
+            self.assertEqual(out.iloc[0]["example_wc"], 10)
+            self.assertEqual(out.iloc[0]["sample_wc"], 10)
+            self.assertEqual(out.iloc[0]["demonstration_wc"], 10)

--- a/sr-data/src/tests/to-swc.csv
+++ b/sr-data/src/tests/to-swc.csv
@@ -1,0 +1,77 @@
+repo,readme
+foo/bar,"Keycloak Open Policy Integration Demo
+----
+
+Example code for integrating Open Policy Agent with Keycloak presented at Keycloak Dev Day 2024.
+
+[Slides](keycloak-devday-2024-flexible-authz-for-keycloak-with-openpolicyagent.pdf)
+
+# Build
+
+```
+mvn clean package -DskipTests
+```
+
+# Run
+
+## Run with HTTP
+
+Start the docker compose setup with Keycloak, Open Policy Agent, Mail server.
+
+```
+docker compose -f dev/docker-compose.yml up
+```
+
+## Run with HTTPS
+
+This example uses https://id.kubecon.test:8443/auth as the Keycloak auth server URL.
+
+To use the example with https just add a mapping for `id.kubecon.test` to your `/etc/hosts` file
+and regenerate the certificates via the [mkcert](https://github.com/FiloSottile/mkcert) tool first.
+
+Then start the `dev/docker-compose-https.yml` docker compose file.
+
+´´´
+(cd dev/config/certs && mkcert -install && mkcert -cert-file kubecon.pem -key-file kubecon-key.pem ""*.kubecon.test"")
+
+docker compose -f dev/docker-compose-https.yml up
+´´´
+
+# Demo
+
+Once up, you can access Keycloak via http://localhost:8080/auth and login with `admin/admin`.
+
+The demo contains a realm called `opademo` that is configured via `dev/config/realms/opademo.yaml`
+through [keycloak-config-cli](https://github.com/adorsys/keycloak-config-cli).
+
+## Users
+
+The example contains a few users to demonstrate various aspects.
+
+- Username: ""tester"" with Password: ""test""
+- Username: ""admin"" with Password: ""test""
+- Username: ""guest"" with Password: ""test""
+
+## Clients
+
+The `opademo` realm contains a few client applications to demonstrate various access policies expressed
+with the REGO Policy language provided by OpenPolicyAgent.
+
+## OPA Access Policy
+
+The client access policies are defined in the file `dev/opa/policies/keycloak/realms/opademo/access/policy.rego`.
+For this demo Open Policy Agent is configured to watch the file for changes and will automatically
+update the policies on change.
+
+To enable the policy check, go to `opademo Realm` -> `Authentication` -> `Required Actions` -> `Enable: OPA Policy Check`.
+
+## Realm configuration
+
+The realm with the clients, roles, groups and users are defined in the `dev/config/realms/opademo.yaml`
+config file.
+
+For the demo the `tester` user can be granted more access incrementally by uncommenting the role / group memeber ship mapping in the `opademo.yaml` file.
+
+To apply the changed realm configuration to the running Keycloak instance, just execute the following command:
+
+`docker restart dev-keycloak-provisioning-1`."


### PR DESCRIPTION
In this pull I've implemented `swc` step, in order to count special words in each README file. 

closes #138 
History:
- **feat(#138): swc counting**
- **feat(#138): better log message**
- **feat(#138): matches**
- **feat(#138): typo**
- **feat(#138): space between imports**
- **feat(#138): regex**
- **feat(#138): swc**
- **feat(#138): test case**
- **feat(#138): it**
- **feat(#138): w, path**
- **feat(#138): words**

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces a new feature to count special words in README files of repositories. It adds functionality for processing these counts and integrates it into the workflow, along with tests to ensure accuracy.

### Detailed summary
- Added `swc` task in `pyproject.toml` for special word counting.
- Updated `.github/workflows/collect.yml` to include new tasks and file copying.
- Created `main` and `word_count` functions in `sr_data/steps/swc.py` for counting words.
- Added tests in `sr_data/src/tests/test_swc.py` for the new functionality.
- Included sample data in `sr-data/src/tests/to-swc.csv`. 
- Updated `justfile` for repository collection and processing commands.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->