### PR TITLE
feat(#137): mcw step

### DIFF
--- a/.github/workflows/collect.yml
+++ b/.github/workflows/collect.yml
@@ -62,7 +62,8 @@ jobs:
               "${{ inputs.end }}" "repos"
             just pulls "../repos.csv" "$TOKEN" "../repos-with-pulls.csv"
             just filter "../repos-with-pulls.csv" "../after-filter.csv"
-            just swc "../after-filter.csv" "../after-swc.csv"
+            just mcw "../after-filter.csv" "../after-mcw.csv"
+            just swc "../after-mcw.csv" "../after-swc.csv"
             just extract "../after-swc.csv" "../after-extract.csv"
             just maven "../after-extract.csv" "$TOKEN" \
               "../after-maven.csv"
@@ -71,6 +72,7 @@ jobs:
           cp "repos.csv" "collection/${{ inputs.out }}"
           cp "repos-with-pulls.csv" "collection/${{ inputs.out }}"
           cp "after-filter.csv" "collection/${{ inputs.out }}"
+          cp "after-mcw.csv" "collection/${{ inputs.out }}"
           cp "after-swc.csv" "collection/${{ inputs.out }}"
           cp "after-extract.csv" "collection/${{ inputs.out }}"
           cp "after-maven.csv" "collection/${{ inputs.out }}"

--- a/.github/workflows/markdown-lint.yml
+++ b/.github/workflows/markdown-lint.yml
@@ -37,3 +37,5 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: articulate/actions-markdownlint@v1
+        with:
+          ignore: sr-data/src/tests

--- a/_typos.toml
+++ b/_typos.toml
@@ -24,4 +24,4 @@ extend-ignore-identifiers-re = [
     "packgs", # variable name
 ]
 [files]
-extend-exclude = ["*.csv"]
+extend-exclude = ["sr-data/src/tests/*.md", "*.csv"]

--- a/justfile
+++ b/justfile
@@ -91,6 +91,10 @@ filter repos out="experiment/after-filter.csv":
 extract repos out="experiment/after-extract.csv":
   cd sr-data && poetry poe extract --repos "{{repos}}" --out "{{out}}"
 
+# Collect most common words.
+mcw repos out="experiment/after-mcw.csv":
+  cd sr-data && poetry poe mcw --repos "{{repos}}" --out "{{out}}"
+
 # Special words count.
 swc repos out="experiment/after-swc.csv" config="resources/swc-words.txt":
   cd sr-data && poetry poe swc --repos "{{repos}}" --out "{{out}}" \

--- a/sr-data/pyproject.toml
+++ b/sr-data/pyproject.toml
@@ -96,6 +96,10 @@ args = [{name = "repos"}, {name = "out"}, {name = "token"}]
 script = "sr_data.steps.swc:main(repos, out, config)"
 args = [{name = "repos"}, {name = "out"}, {name = "config"}]
 
+[tool.poe.tasks.mcw]
+script = "sr_data.steps.mcw:main(repos, out)"
+args = [{name = "repos"}, {name = "out"}]
+
 [build-system]
 requires = ["setuptools", "wheel"]
 build-backend = "setuptools.build_meta"

--- a/sr-data/pyproject.toml
+++ b/sr-data/pyproject.toml
@@ -40,6 +40,7 @@ scikit-learn = "^1.5.1"
 cohere = "5.9.1"
 loguru = "^0.7.2"
 scikit-fuzzy = "^0.5.0"
+markdown-it-py = "^3.0.0"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^8.2.2"

--- a/sr-data/src/sr_data/steps/extract.py
+++ b/sr-data/src/sr_data/steps/extract.py
@@ -45,8 +45,8 @@ def main(repos, out):
     frame["headings"] = frame["readme"].apply(headings)
     before = len(frame)
     frame = frame.dropna(subset=["headings"])
-    stops = len(frame)
-    logger.info(f"Removed {before - stops} repositories that don't have at least one heading (#)")
+    headingless = len(frame)
+    logger.info(f"Removed {before - headingless} repositories that don't have at least one heading (#)")
     frame["headings"] = frame["headings"].apply(
         lambda readme: remove_stop_words(readme, stopwords.words("english"))
     )
@@ -59,7 +59,7 @@ def main(repos, out):
     )
     frame = frame[frame["headings"].apply(bool)]
     logger.info(
-        f"Removed {stops - len(frame)} repositories that have 0 headings after regex filtering ('{rword}')"
+        f"Removed {headingless - len(frame)} repositories that have 0 headings after regex filtering ('{rword}')"
     )
     frame["top"] = frame["headings"].apply(
         lambda headings: top_words(headings, 5)

--- a/sr-data/src/sr_data/steps/mcw.py
+++ b/sr-data/src/sr_data/steps/mcw.py
@@ -1,0 +1,43 @@
+"""
+Collection of most common words in README.
+"""
+# The MIT License (MIT)
+#
+# Copyright (c) 2024 Aliaksei Bialiauski
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+import pandas as pd
+from loguru import logger
+
+
+def main(repos, out):
+    logger.info("Collecting most common words...")
+    frame = pd.read_csv(repos)
+    frame["rtext"] = frame["readme"].apply(to_rast)
+    frame["mcw"] = frame["rtext"].apply(most_common)
+    frame.to_csv(out, index=False)
+    logger.info(f"Saved output to {out}")
+
+
+def to_rast(readme):
+    return ""
+
+
+def most_common(readme):
+    return []

--- a/sr-data/src/tests/test_mcw.py
+++ b/sr-data/src/tests/test_mcw.py
@@ -1,0 +1,54 @@
+"""
+Tests for collecting most common words.
+"""
+import os
+# The MIT License (MIT)
+#
+# Copyright (c) 2024 Aliaksei Bialiauski
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+import unittest
+
+import pytest
+from markdown_it import MarkdownIt
+from sr_data.steps.mcw import to_words
+
+
+class TestMcw(unittest.TestCase):
+
+    @pytest.mark.fast
+    def test_transforms_readme_to_words(self):
+        with open(
+                os.path.join(
+                    os.path.dirname(os.path.realpath(__file__)), "to-words.md"
+                ),
+                "r"
+        ) as readme:
+            words = len(
+                to_words(
+                    readme.read(),
+                    MarkdownIt()
+                )
+            )
+            expected = 91
+            self.assertEqual(
+                words,
+                expected,
+                f"Parsed words size: {words} don't match with expected: {expected}"
+            )

--- a/sr-data/src/tests/test_mcw.py
+++ b/sr-data/src/tests/test_mcw.py
@@ -24,10 +24,12 @@ import os
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 import unittest
+from tempfile import TemporaryDirectory
 
+import pandas as pd
 import pytest
 from markdown_it import MarkdownIt
-from sr_data.steps.mcw import to_words
+from sr_data.steps.mcw import to_words, main
 
 
 class TestMcw(unittest.TestCase):
@@ -52,3 +54,15 @@ class TestMcw(unittest.TestCase):
                 expected,
                 f"Parsed words size: {words} don't match with expected: {expected}"
             )
+
+    @pytest.mark.fast
+    def test_finds_most_common_words_in_readme(self):
+        with TemporaryDirectory() as temp:
+            path = os.path.join(temp, "mcw.csv")
+            main(
+                os.path.join(
+                    os.path.dirname(os.path.realpath(__file__)), "to-mcw.csv"
+                ),
+                path
+            )
+            self.assertTrue("mcw" in pd.read_csv(path).columns)

--- a/sr-data/src/tests/to-mcw.csv
+++ b/sr-data/src/tests/to-mcw.csv
@@ -1,0 +1,77 @@
+repo,readme
+foo/bar,"Keycloak Open Policy Integration Demo
+----
+
+Example code for integrating Open Policy Agent with Keycloak presented at Keycloak Dev Day 2024.
+
+[Slides](keycloak-devday-2024-flexible-authz-for-keycloak-with-openpolicyagent.pdf)
+
+# Build
+
+```
+mvn clean package -DskipTests
+```
+
+# Run
+
+## Run with HTTP
+
+Start the docker compose setup with Keycloak, Open Policy Agent, Mail server.
+
+```
+docker compose -f dev/docker-compose.yml up
+```
+
+## Run with HTTPS
+
+This example uses https://id.kubecon.test:8443/auth as the Keycloak auth server URL.
+
+To use the example with https just add a mapping for `id.kubecon.test` to your `/etc/hosts` file
+and regenerate the certificates via the [mkcert](https://github.com/FiloSottile/mkcert) tool first.
+
+Then start the `dev/docker-compose-https.yml` docker compose file.
+
+´´´
+(cd dev/config/certs && mkcert -install && mkcert -cert-file kubecon.pem -key-file kubecon-key.pem ""*.kubecon.test"")
+
+docker compose -f dev/docker-compose-https.yml up
+´´´
+
+# Demo
+
+Once up, you can access Keycloak via http://localhost:8080/auth and login with `admin/admin`.
+
+The demo contains a realm called `opademo` that is configured via `dev/config/realms/opademo.yaml`
+through [keycloak-config-cli](https://github.com/adorsys/keycloak-config-cli).
+
+## Users
+
+The example contains a few users to demonstrate various aspects.
+
+- Username: ""tester"" with Password: ""test""
+- Username: ""admin"" with Password: ""test""
+- Username: ""guest"" with Password: ""test""
+
+## Clients
+
+The `opademo` realm contains a few client applications to demonstrate various access policies expressed
+with the REGO Policy language provided by OpenPolicyAgent.
+
+## OPA Access Policy
+
+The client access policies are defined in the file `dev/opa/policies/keycloak/realms/opademo/access/policy.rego`.
+For this demo Open Policy Agent is configured to watch the file for changes and will automatically
+update the policies on change.
+
+To enable the policy check, go to `opademo Realm` -> `Authentication` -> `Required Actions` -> `Enable: OPA Policy Check`.
+
+## Realm configuration
+
+The realm with the clients, roles, groups and users are defined in the `dev/config/realms/opademo.yaml`
+config file.
+
+For the demo the `tester` user can be granted more access incrementally by uncommenting the role / group memeber ship mapping in the `opademo.yaml` file.
+
+To apply the changed realm configuration to the running Keycloak instance, just execute the following command:
+
+`docker restart dev-keycloak-provisioning-1`."

--- a/sr-data/src/tests/to-words.md
+++ b/sr-data/src/tests/to-words.md
@@ -1,0 +1,76 @@
+Keycloak Open Policy Integration Demo
+----
+
+Example code for integrating Open Policy Agent with Keycloak presented at Keycloak Dev Day 2024.
+
+[Slides](keycloak-devday-2024-flexible-authz-for-keycloak-with-openpolicyagent.pdf)
+
+# Build
+
+```
+mvn clean package -DskipTests
+```
+
+# Run
+
+## Run with HTTP
+
+Start the docker compose setup with Keycloak, Open Policy Agent, Mail server.
+
+```
+docker compose -f dev/docker-compose.yml up
+```
+
+## Run with HTTPS
+
+This example uses https://id.kubecon.test:8443/auth as the Keycloak auth server URL.
+
+To use the example with https just add a mapping for `id.kubecon.test` to your `/etc/hosts` file
+and regenerate the certificates via the [mkcert](https://github.com/FiloSottile/mkcert) tool first.
+
+Then start the `dev/docker-compose-https.yml` docker compose file.
+
+´´´
+(cd dev/config/certs && mkcert -install && mkcert -cert-file kubecon.pem -key-file kubecon-key.pem "*.kubecon.test")
+
+docker compose -f dev/docker-compose-https.yml up
+´´´
+
+# Demo
+
+Once up, you can access Keycloak via http://localhost:8080/auth and login with `admin/admin`.
+
+The demo contains a realm called `opademo` that is configured via `dev/config/realms/opademo.yaml`
+through [keycloak-config-cli](https://github.com/adorsys/keycloak-config-cli).
+
+## Users
+
+The example contains a few users to demonstrate various aspects.
+
+- Username: "tester" with Password: "test"
+- Username: "admin" with Password: "test"
+- Username: "guest" with Password: "test"
+
+## Clients
+
+The `opademo` realm contains a few client applications to demonstrate various access policies expressed
+with the REGO Policy language provided by OpenPolicyAgent. 
+
+## OPA Access Policy
+
+The client access policies are defined in the file `dev/opa/policies/keycloak/realms/opademo/access/policy.rego`. 
+For this demo Open Policy Agent is configured to watch the file for changes and will automatically
+update the policies on change.
+
+To enable the policy check, go to `opademo Realm` -> `Authentication` -> `Required Actions` -> `Enable: OPA Policy Check`.
+
+## Realm configuration
+
+The realm with the clients, roles, groups and users are defined in the `dev/config/realms/opademo.yaml` 
+config file. 
+
+For the demo the `tester` user can be granted more access incrementally by uncommenting the role / group memeber ship mapping in the `opademo.yaml` file.
+
+To apply the changed realm configuration to the running Keycloak instance, just execute the following command:
+
+`docker restart dev-keycloak-provisioning-1`.


### PR DESCRIPTION
In this pull I've implemented `mcw` step for collecting _most common words_ in each README.

closes #137
History:
- **feat(#137): to_rast -> mcw**
- **feat(#137): rtext**
- **feat(#137): words**
- **feat(#137): markdownit package, puzzles**
- **feat(#137): transforms readme**
- **feat(#137): most common words test case**
- **feat(#137): in collect.yml**

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enhancing the functionality for collecting and processing the most common words from README files. It introduces new tasks, modifies workflows, and adds tests to ensure the correctness of the new features.

### Detailed summary
- Updated `extend-exclude` in `_typos.toml` to include Markdown files.
- Modified `.github/workflows/markdown-lint.yml` to ignore specific directories.
- Added a new task `mcw` in `justfile` for collecting most common words.
- Updated `pyproject.toml` to include `markdown-it-py` dependency.
- Introduced new `mcw` task in the Poetry configuration.
- Changed workflow in `.github/workflows/collect.yml` to process most common words.
- Updated logging in `sr-data/src/sr_data/steps/extract.py` for clarity.
- Created tests in `sr-data/src/tests/test_mcw.py` for `mcw` functionality.
- Added example README content in `sr-data/src/tests/to-words.md` and `sr-data/src/tests/to-mcw.csv`.
- Implemented the `to_words`, `remove_stop_words`, `lemmatize`, and `most_common` functions in `sr-data/src/sr_data/steps/mcw.py`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->