### PR TITLE
feat(#143): tokenize into words before removing stop words

### DIFF
--- a/sr-data/src/sr_data/steps/mcw.py
+++ b/sr-data/src/sr_data/steps/mcw.py
@@ -42,8 +42,8 @@ from sr_data.steps.extract import wordnet_pos, filter
 #  'you', 'a'] and etc. We should remove such words too. Don't forget to create
 #  unit tests.
 def main(repos, out):
-    logger.info("Collecting most common words...")
     frame = pd.read_csv(repos)
+    logger.info(f"Collecting most common words in {len(frame)} repositories...")
     frame["words"] = frame["readme"].apply(
         lambda readme: to_words(readme, MarkdownIt())
     )

--- a/sr-data/src/sr_data/steps/mcw.py
+++ b/sr-data/src/sr_data/steps/mcw.py
@@ -62,7 +62,7 @@ def main(repos, out):
     )
     frame["mcw"] = frame["words"].apply(most_common)
     frame.to_csv(out, index=False)
-    logger.info(f"Saved output to {out}")
+    logger.info(f"Saved {len(frame)} repositories to {out}")
 
 
 def to_words(readme, mit):

--- a/sr-data/src/sr_data/steps/mcw.py
+++ b/sr-data/src/sr_data/steps/mcw.py
@@ -37,10 +37,6 @@ from sr_data.steps.extract import wordnet_pos, filter
 #  extract.py step. Now we are duplicating logic, only slightly changing it to
 #  fit the input, will be more traceable to reuse existing methods located in
 #  extract.py.
-# @todo #137:45min Stop words filtering is weak.
-#  method remove_stop_words doesn't remove such words as: ['the', 'to', 'and',
-#  'you', 'a'] and etc. We should remove such words too. Don't forget to create
-#  unit tests.
 def main(repos, out):
     frame = pd.read_csv(repos)
     logger.info(f"Collecting most common words in {len(frame)} repositories...")
@@ -83,7 +79,7 @@ def to_words(readme, mit):
                     text.append(child.content)
         elif tkn.type not in skip and tkn.type.endswith("_open"):
             text.append(tkn.content)
-    return text
+    return word_tokenize(" ".join(text))
 
 
 def remove_stop_words(words, stopwords):

--- a/sr-data/src/sr_data/steps/mcw.py
+++ b/sr-data/src/sr_data/steps/mcw.py
@@ -1,8 +1,6 @@
 """
 Collection of most common words in README.
 """
-from collections import Counter
-
 # The MIT License (MIT)
 #
 # Copyright (c) 2024 Aliaksei Bialiauski
@@ -24,6 +22,8 @@ from collections import Counter
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
+from collections import Counter
+
 import pandas as pd
 from loguru import logger
 from markdown_it import MarkdownIt

--- a/sr-data/src/tests/test_mcw.py
+++ b/sr-data/src/tests/test_mcw.py
@@ -48,7 +48,7 @@ class TestMcw(unittest.TestCase):
                     MarkdownIt()
                 )
             )
-            expected = 91
+            expected = 326
             self.assertEqual(
                 words,
                 expected,
@@ -65,4 +65,7 @@ class TestMcw(unittest.TestCase):
                 ),
                 path
             )
-            self.assertTrue("mcw" in pd.read_csv(path).columns)
+            self.assertEqual(
+                pd.read_csv(path).iloc[0]["mcw"],
+                "['policy', 'keycloak', 'file', 'demo', 'http']"
+            )


### PR DESCRIPTION
In this pull I've fixed bug with weak stop word filtering, by tokenizing text into words in `to_words()` function.

closes #143
History:
- **feat(#143): order**
- **feat(#143): len**
- **feat(#143): len 2x**
- **feat(#143): tokenize to_words**
- **feat(#143): test case**


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the tests and the main functionality of the `mcw.py` script to improve the collection and reporting of the most common words in README files, as well as enhancing the assertions in the test cases.

### Detailed summary
- Updated the expected value in `test_mcw.py` from `91` to `326`.
- Changed the assertion to check if the first row of the `mcw` column matches the string representation of a list of words.
- Modified the logging message in `mcw.py` to include the count of repositories processed.
- Updated the `to_words` function to tokenize the words more effectively using `word_tokenize`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->