### PR TITLE
feat(#141): embeddings from mcw

### DIFF
--- a/sr-data/src/sr_data/steps/embed.py
+++ b/sr-data/src/sr_data/steps/embed.py
@@ -56,7 +56,7 @@ def main(repos, prefix, hf, cohere):
             embed_cohere(cohere, frame, prefix)
         else:
             logger.info(f"Inference checkpoint: {checkpoint}")
-            embeddings = pd.DataFrame(infer(frame["top"].tolist(), checkpoint, hf))
+            embeddings = pd.DataFrame(infer(frame["mcw"].tolist(), checkpoint, hf))
             embeddings.insert(0, 'repo', frame["repo"])
             embeddings.to_csv(f"{prefix}-{model}.csv", index=False)
         logger.info(

--- a/sr-data/src/sr_data/steps/extract.py
+++ b/sr-data/src/sr_data/steps/extract.py
@@ -61,7 +61,7 @@ def main(repos, out):
     logger.info(
         f"Removed {headingless - len(frame)} repositories that have 0 headings after regex filtering ('{rword}')"
     )
-    frame["top"] = frame["headings"].apply(
+    frame["mcw"] = frame["headings"].apply(
         lambda headings: top_words(headings, 5)
     )
     frame.to_csv(out, index=False)

--- a/sr-data/src/tests/test_embed.py
+++ b/sr-data/src/tests/test_embed.py
@@ -98,7 +98,7 @@ class TestEmbed(unittest.TestCase):
         with TemporaryDirectory() as temp:
             main(
                 os.path.join(
-                    os.path.dirname(os.path.realpath(__file__)), "embed.csv"
+                    os.path.dirname(os.path.realpath(__file__)), "to-embed.csv"
                 ),
                 temp,
                 os.environ["HF_TESTING_TOKEN"],

--- a/sr-data/src/tests/to-embed.csv
+++ b/sr-data/src/tests/to-embed.csv
@@ -1,2 +1,2 @@
-repo,top
+repo,mcw
 foo,"['test', 'dummy']"


### PR DESCRIPTION
closes #141

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the handling of data related to repositories by changing the column name from `top` to `mcw` and updating the associated CSV file for testing. It reflects a shift in the data structure used in the embedding process.

### Detailed summary
- Renamed `embed.csv` to `to-embed.csv`.
- Updated the file path in `test_embed.py` to reference `to-embed.csv`.
- Changed the DataFrame column from `top` to `mcw` in `extract.py`.
- Updated the embedding process to use `mcw` instead of `top` in `embed.py`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->