### PR TITLE
feat(#156): mcw column in `embed` step

### DIFF
--- a/sr-data/src/sr_data/steps/embed.py
+++ b/sr-data/src/sr_data/steps/embed.py
@@ -44,7 +44,7 @@ def main(repos, prefix, hf, cohere):
     :param cohere Cohere token
     """
     frame = pd.read_csv(repos)
-    frame["top"] = frame["top"].apply(
+    frame["mcw"] = frame["mcw"].apply(
         lambda words:
         words.replace("[", "").replace("]", "").replace("'", "")
     )
@@ -69,7 +69,7 @@ def embed_cohere(key, texts, prefix):
     embeddings = pd.DataFrame(
         np.asarray(
             client.embed(
-                texts=texts["top"].tolist(), input_type="search_document", model="embed-english-v3.0"
+                texts=texts["mcw"].tolist(), input_type="search_document", model="embed-english-v3.0"
             ).embeddings
         )
     )


### PR DESCRIPTION
closes #156

<!-- start pr-codex -->

---

## PR-Codex overview
This PR modifies the way data is processed in the `embed.py` file by changing the column used for text embedding from `top` to `mcw`. This adjustment likely reflects a change in the data source or the intended input for the embedding function.

### Detailed summary
- Changed the assignment of `top` column to `mcw` in the DataFrame.
- Updated the `texts` parameter in the `client.embed` function to use `mcw` instead of `top`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->