### PR TITLE
feat(#149): rlen, avg_slen, avg_wlen

### DIFF
--- a/justfile
+++ b/justfile
@@ -100,6 +100,10 @@ swc repos out="experiment/after-swc.csv" config="resources/swc-words.txt":
   cd sr-data && poetry poe swc --repos "{{repos}}" --out "{{out}}" \
     --config "{{config}}"
 
+# Calculate length metrics.
+lens repos out="experiment/after-lens.csv":
+  cd sr-data && poetry poe lens --repos {{repos}} --out {{out}}
+
 # Create embeddings.
 embed repos prefix="experiment/embeddings":
   cd sr-data && poetry poe embed --repos {{repos}} --prefix {{prefix}} \

--- a/sr-data/pyproject.toml
+++ b/sr-data/pyproject.toml
@@ -101,6 +101,10 @@ args = [{name = "repos"}, {name = "out"}, {name = "config"}]
 script = "sr_data.steps.mcw:main(repos, out)"
 args = [{name = "repos"}, {name = "out"}]
 
+[tool.poe.tasks.lens]
+script = "sr_data.steps.lens:main(repos, out)"
+args = [{name = "repos"}, {name = "out"}]
+
 [build-system]
 requires = ["setuptools", "wheel"]
 build-backend = "setuptools.build_meta"

--- a/sr-data/src/sr_data/steps/lens.py
+++ b/sr-data/src/sr_data/steps/lens.py
@@ -28,10 +28,22 @@ from loguru import logger
 
 def main(repos, out):
     frame = pd.read_csv(repos)
-    logger.info(f"Calculating length metrics for {len(frame)} repositories")
+    logger.info(
+        f"Calculating `rlen`, `avg_slen`, `avg_wlen` for {len(frame)} repositories"
+    )
     frame["rlen"] = frame["readme"].apply(rlen)
+    frame["avg_slen"] = frame["readme"].apply(avg_slen)
+    frame["avg_wlen"] = frame["readme"].apply(avg_wlen)
     frame.to_csv(out, index=False)
 
 
 def rlen(readme):
     return len(readme)
+
+
+def avg_slen(readme):
+    return 0
+
+
+def avg_wlen(readme):
+    return 0

--- a/sr-data/src/sr_data/steps/lens.py
+++ b/sr-data/src/sr_data/steps/lens.py
@@ -1,0 +1,37 @@
+"""
+Calculate length metrics for READMEs.
+"""
+# The MIT License (MIT)
+#
+# Copyright (c) 2024 Aliaksei Bialiauski
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+import pandas as pd
+from loguru import logger
+
+
+def main(repos, out):
+    frame = pd.read_csv(repos)
+    logger.info(f"Calculating length metrics for {len(frame)} repositories")
+    frame["rlen"] = frame["readme"].apply(rlen)
+    frame.to_csv(out, index=False)
+
+
+def rlen(readme):
+    return len(readme)

--- a/sr-data/src/sr_data/steps/lens.py
+++ b/sr-data/src/sr_data/steps/lens.py
@@ -22,6 +22,9 @@ Calculate length metrics for READMEs.
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
+import re
+
+import nltk
 import pandas as pd
 from loguru import logger
 
@@ -35,6 +38,7 @@ def main(repos, out):
     frame["avg_slen"] = frame["readme"].apply(avg_slen)
     frame["avg_wlen"] = frame["readme"].apply(avg_wlen)
     frame.to_csv(out, index=False)
+    logger.info(f"Saved {len(frame)} repositories to {out}")
 
 
 def rlen(readme):
@@ -42,7 +46,12 @@ def rlen(readme):
 
 
 def avg_slen(readme):
-    return 0
+    sentences = nltk.sent_tokenize(readme)
+    total = sum(len(re.findall(r'\w+', sentence)) for sentence in sentences)
+    result = 0
+    if sentences:
+        result = total / len(sentences)
+    return result
 
 
 def avg_wlen(readme):

--- a/sr-data/src/sr_data/steps/lens.py
+++ b/sr-data/src/sr_data/steps/lens.py
@@ -55,4 +55,9 @@ def avg_slen(readme):
 
 
 def avg_wlen(readme):
-    return 0
+    words = re.findall(r'\w+', readme)
+    total = sum(len(word) for word in words)
+    result = 0
+    if words:
+        result = total / len(words)
+    return result

--- a/sr-data/src/tests/test_lens.py
+++ b/sr-data/src/tests/test_lens.py
@@ -1,7 +1,6 @@
 """
 Tests for lens.
 """
-import os.path
 # The MIT License (MIT)
 #
 # Copyright (c) 2024 Aliaksei Bialiauski
@@ -23,6 +22,7 @@ import os.path
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
+import os.path
 import unittest
 from tempfile import TemporaryDirectory
 
@@ -76,6 +76,6 @@ class TestLens(unittest.TestCase):
                 path
             )
             frame = pd.read_csv(path)
-            self.assertEqual(frame.iloc[0]["rlen"],2487)
-            self.assertEqual(frame.iloc[0]["avg_slen"],24.666666666666668)
-            self.assertEqual(frame.iloc[0]["avg_wlen"],5.1567567567567565)
+            self.assertEqual(frame.iloc[0]["rlen"], 2487)
+            self.assertEqual(frame.iloc[0]["avg_slen"], 24.666666666666668)
+            self.assertEqual(frame.iloc[0]["avg_wlen"], 5.1567567567567565)

--- a/sr-data/src/tests/test_lens.py
+++ b/sr-data/src/tests/test_lens.py
@@ -1,0 +1,39 @@
+"""
+Tests for lens.
+"""
+# The MIT License (MIT)
+#
+# Copyright (c) 2024 Aliaksei Bialiauski
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+import unittest
+
+from sr_data.steps.lens import rlen
+
+
+class TestLens(unittest.TestCase):
+
+    def test_calculates_rlen(self):
+        length = rlen("This is test readme. Foo bar")
+        expected = 22
+        self.assertEqual(
+            length,
+            expected,
+            f"Calculated length: {length} does not match with expected: {expected}"
+        )

--- a/sr-data/src/tests/test_lens.py
+++ b/sr-data/src/tests/test_lens.py
@@ -1,6 +1,7 @@
 """
 Tests for lens.
 """
+import os.path
 # The MIT License (MIT)
 #
 # Copyright (c) 2024 Aliaksei Bialiauski
@@ -23,9 +24,11 @@ Tests for lens.
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 import unittest
+from tempfile import TemporaryDirectory
 
+import pandas as pd
 import pytest
-from sr_data.steps.lens import rlen, avg_slen, avg_wlen
+from sr_data.steps.lens import rlen, avg_slen, avg_wlen, main
 
 
 class TestLens(unittest.TestCase):
@@ -62,3 +65,17 @@ class TestLens(unittest.TestCase):
             f"Calculated avg_wlen: {length} does not match with expected: {expected}"
         )
 
+    @pytest.mark.fast
+    def test_calculates_all_lengths(self):
+        with TemporaryDirectory() as temp:
+            path = os.path.join(temp, "lens.csv")
+            main(
+                os.path.join(
+                    os.path.dirname(os.path.realpath(__file__)), "to-lens.csv"
+                ),
+                path
+            )
+            frame = pd.read_csv(path)
+            self.assertEqual(frame.iloc[0]["rlen"],2487)
+            self.assertEqual(frame.iloc[0]["avg_slen"],24.666666666666668)
+            self.assertEqual(frame.iloc[0]["avg_wlen"],5.1567567567567565)

--- a/sr-data/src/tests/test_lens.py
+++ b/sr-data/src/tests/test_lens.py
@@ -24,7 +24,7 @@ Tests for lens.
 # SOFTWARE.
 import unittest
 
-from sr_data.steps.lens import rlen
+from sr_data.steps.lens import rlen, avg_slen
 
 
 class TestLens(unittest.TestCase):
@@ -36,4 +36,15 @@ class TestLens(unittest.TestCase):
             length,
             expected,
             f"Calculated length: {length} does not match with expected: {expected}"
+        )
+
+    def test_calculates_avg_slen(self):
+        length = avg_slen(
+            "This is another test readme. Very very long sentence. Short."
+        )
+        expected = 2
+        self.assertEqual(
+            length,
+            expected,
+            f"Calculated avg_slen: {length} does not match with expected: {expected}"
         )

--- a/sr-data/src/tests/test_lens.py
+++ b/sr-data/src/tests/test_lens.py
@@ -24,34 +24,38 @@ Tests for lens.
 # SOFTWARE.
 import unittest
 
+import pytest
 from sr_data.steps.lens import rlen, avg_slen, avg_wlen
 
 
 class TestLens(unittest.TestCase):
 
+    @pytest.mark.fast
     def test_calculates_rlen(self):
         length = rlen("This is test readme. Foo bar")
-        expected = 22
+        expected = 28
         self.assertEqual(
             length,
             expected,
             f"Calculated rlen: {length} does not match with expected: {expected}"
         )
 
+    @pytest.mark.fast
     def test_calculates_avg_slen(self):
         length = avg_slen(
             "This is another test readme. Very very long sentence. Short."
         )
-        expected = 2
+        expected = 3.3333333333333335
         self.assertEqual(
             length,
             expected,
             f"Calculated avg_slen: {length} does not match with expected: {expected}"
         )
 
+    @pytest.mark.fast
     def test_calculates_avg_wlen(self):
         length = avg_wlen("This is test readme for avg_wlen test.")
-        expected = 4.5
+        expected = 4.428571428571429
         self.assertEqual(
             length,
             expected,

--- a/sr-data/src/tests/test_lens.py
+++ b/sr-data/src/tests/test_lens.py
@@ -24,7 +24,7 @@ Tests for lens.
 # SOFTWARE.
 import unittest
 
-from sr_data.steps.lens import rlen, avg_slen
+from sr_data.steps.lens import rlen, avg_slen, avg_wlen
 
 
 class TestLens(unittest.TestCase):
@@ -35,7 +35,7 @@ class TestLens(unittest.TestCase):
         self.assertEqual(
             length,
             expected,
-            f"Calculated length: {length} does not match with expected: {expected}"
+            f"Calculated rlen: {length} does not match with expected: {expected}"
         )
 
     def test_calculates_avg_slen(self):
@@ -48,3 +48,13 @@ class TestLens(unittest.TestCase):
             expected,
             f"Calculated avg_slen: {length} does not match with expected: {expected}"
         )
+
+    def test_calculates_avg_wlen(self):
+        length = avg_wlen("This is test readme for avg_wlen test.")
+        expected = 4.5
+        self.assertEqual(
+            length,
+            expected,
+            f"Calculated avg_wlen: {length} does not match with expected: {expected}"
+        )
+

--- a/sr-data/src/tests/to-lens.csv
+++ b/sr-data/src/tests/to-lens.csv
@@ -1,0 +1,77 @@
+repo,readme
+foo/bar,"Keycloak Open Policy Integration Demo
+----
+
+Example code for integrating Open Policy Agent with Keycloak presented at Keycloak Dev Day 2024.
+
+[Slides](keycloak-devday-2024-flexible-authz-for-keycloak-with-openpolicyagent.pdf)
+
+# Build
+
+```
+mvn clean package -DskipTests
+```
+
+# Run
+
+## Run with HTTP
+
+Start the docker compose setup with Keycloak, Open Policy Agent, Mail server.
+
+```
+docker compose -f dev/docker-compose.yml up
+```
+
+## Run with HTTPS
+
+This example uses https://id.kubecon.test:8443/auth as the Keycloak auth server URL.
+
+To use the example with https just add a mapping for `id.kubecon.test` to your `/etc/hosts` file
+and regenerate the certificates via the [mkcert](https://github.com/FiloSottile/mkcert) tool first.
+
+Then start the `dev/docker-compose-https.yml` docker compose file.
+
+´´´
+(cd dev/config/certs && mkcert -install && mkcert -cert-file kubecon.pem -key-file kubecon-key.pem ""*.kubecon.test"")
+
+docker compose -f dev/docker-compose-https.yml up
+´´´
+
+# Demo
+
+Once up, you can access Keycloak via http://localhost:8080/auth and login with `admin/admin`.
+
+The demo contains a realm called `opademo` that is configured via `dev/config/realms/opademo.yaml`
+through [keycloak-config-cli](https://github.com/adorsys/keycloak-config-cli).
+
+## Users
+
+The example contains a few users to demonstrate various aspects.
+
+- Username: ""tester"" with Password: ""test""
+- Username: ""admin"" with Password: ""test""
+- Username: ""guest"" with Password: ""test""
+
+## Clients
+
+The `opademo` realm contains a few client applications to demonstrate various access policies expressed
+with the REGO Policy language provided by OpenPolicyAgent.
+
+## OPA Access Policy
+
+The client access policies are defined in the file `dev/opa/policies/keycloak/realms/opademo/access/policy.rego`.
+For this demo Open Policy Agent is configured to watch the file for changes and will automatically
+update the policies on change.
+
+To enable the policy check, go to `opademo Realm` -> `Authentication` -> `Required Actions` -> `Enable: OPA Policy Check`.
+
+## Realm configuration
+
+The realm with the clients, roles, groups and users are defined in the `dev/config/realms/opademo.yaml`
+config file.
+
+For the demo the `tester` user can be granted more access incrementally by uncommenting the role / group memeber ship mapping in the `opademo.yaml` file.
+
+To apply the changed realm configuration to the running Keycloak instance, just execute the following command:
+
+`docker restart dev-keycloak-provisioning-1`."


### PR DESCRIPTION
In this pull I've introduced new metrics for each repository: `rlen`, `avg_slen`, `avg_wlen`.

closes #149
History:
- **feat(#149): lens**
- **feat(#149): stubs**
- **feat(#149): slen**
- **feat(#149): avg_wlen**
- **feat(#149): rlen test cases**
- **feat(#149): avg_slen test case**
- **feat(#149): avg_wlen test case**
- **feat(#149): values**
- **feat(#149): values**
- **feat(#149): clean**

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces a new task for calculating length metrics of README files, adds a script to perform these calculations, and includes tests for the implemented functions. It also updates configuration files to accommodate these changes.

### Detailed summary
- Added `[tool.poe.tasks.lens]` in `pyproject.toml` for length metrics task.
- Created `main` function in `sr_data/steps/lens.py` to calculate `rlen`, `avg_slen`, and `avg_wlen`.
- Implemented helper functions: `rlen`, `avg_slen`, and `avg_wlen`.
- Added example data in `to-lens.csv` for testing.
- Created unit tests for length calculation functions in `test_lens.py`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->