### PR TITLE
fix(#164): defaults for non-maven repository

### DIFF
--- a/sr-data/src/sr_data/steps/maven.py
+++ b/sr-data/src/sr_data/steps/maven.py
@@ -50,6 +50,10 @@ def main(repos, out, token):
             frame.at[idx, "ppoms"] = profile["packages"]["poms"]
         else:
             frame.at[idx, "projects"] = 0
+            frame.at[idx, "plugins"] = "[]"
+            frame.at[idx, "pwars"] = 0
+            frame.at[idx, "pjars"] = 0
+            frame.at[idx, "ppoms"] = 0
     before = len(frame)
     frame = frame[frame.projects != 0]
     logger.info(f"Skipped {before - len(frame)} repositories without pom.xml files")

--- a/sr-data/src/tests/test_final.py
+++ b/sr-data/src/tests/test_final.py
@@ -46,3 +46,17 @@ class TestFinal(unittest.TestCase):
             final = pd.read_csv(path)
             self.assertEqual(len(final.columns), 18)
             self.assertEqual(len(final), 1)
+
+    @pytest.mark.fast
+    def test_composes_empty(self):
+        with TemporaryDirectory() as temp:
+            path = os.path.join(temp, "final.csv")
+            main(
+                os.path.join(
+                    os.path.dirname(os.path.realpath(__file__)), "to-final-empty.csv"
+                ),
+                path
+            )
+            final = pd.read_csv(path)
+            self.assertEqual(len(final.columns), 18)
+            self.assertEqual(len(final), 0)

--- a/sr-data/src/tests/test_maven.py
+++ b/sr-data/src/tests/test_maven.py
@@ -87,7 +87,6 @@ class TestMaven(unittest.TestCase):
                 "[org.jetbrains.kotlin:kotlin-maven-plugin,org.springframework.boot:spring-boot-maven-plugin]"
             )
 
-
     @pytest.mark.fast
     def test_merges_projects_in_one_profile(self):
         merged = merge(
@@ -108,3 +107,23 @@ class TestMaven(unittest.TestCase):
         self.assertEqual(merged["packages"]["jars"], 2)
         self.assertEqual(merged["packages"]["wars"], 0)
         self.assertEqual(merged["packages"]["poms"], 0)
+
+    @pytest.mark.nightly
+    def test_returns_default_values_for_non_maven(self):
+        with TemporaryDirectory() as temp:
+            path = os.path.join(temp, "maven.csv")
+            main(
+                os.path.join(
+                    os.path.dirname(os.path.realpath(__file__)),
+                    "to-maven-non-maven.csv"
+                ),
+                path,
+                os.environ["GH_TESTING_TOKEN"]
+            )
+            frame = pd.read_csv(path)
+            self.assertEqual(len(frame.columns), 7)
+            self.assertTrue("projects" in frame.columns)
+            self.assertTrue("plugins" in frame.columns)
+            self.assertTrue("pwars" in frame.columns)
+            self.assertTrue("pjars" in frame.columns)
+            self.assertTrue("ppoms" in frame.columns)

--- a/sr-data/src/tests/to-final-empty.csv
+++ b/sr-data/src/tests/to-final-empty.csv
@@ -1,0 +1,1 @@
+repo,branch,readme,releases,issues,branches,pulls,headings,top,projects,plugins,pwars,pjars,ppoms,hnum,rlen,avg_slen,avg_wlen,mcw,example_wc,sample_wc,demonstration_wc

--- a/sr-data/src/tests/to-maven-non-maven.csv
+++ b/sr-data/src/tests/to-maven-non-maven.csv
@@ -1,0 +1,2 @@
+repo,branch
+h1alexbel/fakehub,master


### PR DESCRIPTION
ref #164 

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces enhancements to handle non-Maven projects by adding new columns to CSV files and updating tests to ensure proper functionality.

### Detailed summary
- Added `repo` and `branch` columns to `to-maven-non-maven.csv`.
- Expanded `to-final-empty.csv` with additional columns.
- Updated `maven.py` to initialize new columns: `plugins`, `pwars`, `pjars`, and `ppoms`.
- Added a new test `test_composes_empty` in `test_final.py`.
- Introduced `test_returns_default_values_for_non_maven` in `test_maven.py` to validate new columns in the processed data.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->