### PR TITLE
feat(#151): snippets step

### DIFF
--- a/.github/workflows/collect.yml
+++ b/.github/workflows/collect.yml
@@ -73,7 +73,8 @@ jobs:
             just mcw "../after-filter.csv" "../after-mcw.csv"
             just swc "../after-mcw.csv" "../after-swc.csv"
             just extract "../after-swc.csv" "../after-extract.csv"
-            just maven "../after-extract.csv" "$TOKEN" \
+            just snippets "../after-extract.csv" "../after-snippets.csv" 
+            just maven "../after-snippets.csv" "$TOKEN" \
               "../after-maven.csv"
             just lens "../after-maven.csv" "../after-lens.csv"
             just final "../after-lens.csv" "../final.csv"
@@ -86,6 +87,7 @@ jobs:
           cp "after-mcw.csv" "collection/${{ inputs.out }}/steps/"
           cp "after-swc.csv" "collection/${{ inputs.out }}/steps/"
           cp "after-extract.csv" "collection/${{ inputs.out }}/steps/"
+          cp "after-snippets.csv" "collection/${{ inputs.out }}/steps/"
           cp "after-maven.csv" "collection/${{ inputs.out }}/steps/"
           cp "after-lens.csv" "collection/${{ inputs.out }}/steps/"
           cp "collect.log" "collection/${{ inputs.out }}"

--- a/.github/workflows/collect.yml
+++ b/.github/workflows/collect.yml
@@ -73,7 +73,7 @@ jobs:
             just mcw "../after-filter.csv" "../after-mcw.csv"
             just swc "../after-mcw.csv" "../after-swc.csv"
             just extract "../after-swc.csv" "../after-extract.csv"
-            just snippets "../after-extract.csv" "../after-snippets.csv" 
+            just snippets "../after-extract.csv" "../after-snippets.csv"
             just maven "../after-snippets.csv" "$TOKEN" \
               "../after-maven.csv"
             just lens "../after-maven.csv" "../after-lens.csv"

--- a/justfile
+++ b/justfile
@@ -108,6 +108,10 @@ lens repos out="experiment/after-lens.csv":
 final latest out="experiment/final.csv":
   cd sr-data && poetry poe final --latest {{latest}} --out {{out}}
 
+# Count snippets.
+snippets repos out="experiment/after-snippets.csv":
+  cd sr-data && poetry poe snippets --repos {{repos}} --out {{out}}
+
 # Create embeddings.
 embed repos prefix="experiment/embeddings":
   cd sr-data && poetry poe embed --repos {{repos}} --prefix {{prefix}} \

--- a/sr-data/pyproject.toml
+++ b/sr-data/pyproject.toml
@@ -109,6 +109,10 @@ args = [{name = "repos"}, {name = "out"}]
 script = "sr_data.steps.final:main(latest, out)"
 args = [{name = "latest"}, {name = "out"}]
 
+[tool.poe.tasks.snippets]
+script = "sr_data.steps.snippets:main(repos, out)"
+args = [{name = "repos"}, {name = "out"}]
+
 [build-system]
 requires = ["setuptools", "wheel"]
 build-backend = "setuptools.build_meta"

--- a/sr-data/src/sr_data/steps/final.py
+++ b/sr-data/src/sr_data/steps/final.py
@@ -46,7 +46,9 @@ def main(latest, out):
             "rlen",
             "avg_slen",
             "avg_wlen",
-            "hnum"
+            "hnum",
+            "snippets"
         ]
     ]
     frame.to_csv(out, index=False)
+

--- a/sr-data/src/sr_data/steps/snippets.py
+++ b/sr-data/src/sr_data/steps/snippets.py
@@ -1,0 +1,36 @@
+"""
+Snippets in README.
+"""
+# The MIT License (MIT)
+#
+# Copyright (c) 2024 Aliaksei Bialiauski
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+import pandas as pd
+from loguru import logger
+
+
+def main(repos, out):
+    frame = pd.read_csv(repos)
+    logger.info(f"Counting snippets in READMEs for {len(frame)} repositories")
+    frame["snippets"] = frame["readme"].apply(snippets)
+
+
+def snippets(readme):
+    return 0

--- a/sr-data/src/sr_data/steps/snippets.py
+++ b/sr-data/src/sr_data/steps/snippets.py
@@ -30,7 +30,9 @@ def main(repos, out):
     frame = pd.read_csv(repos)
     logger.info(f"Counting snippets in READMEs for {len(frame)} repositories")
     frame["snippets"] = frame["readme"].apply(snippets)
+    frame.to_csv(out, index=False)
+    logger.info(f"Saved {len(frame)} repositories with snippets to {out}")
 
 
 def snippets(readme):
-    return 0
+    return len(readme.split("```")) // 2

--- a/sr-data/src/tests/test_final.py
+++ b/sr-data/src/tests/test_final.py
@@ -44,7 +44,7 @@ class TestFinal(unittest.TestCase):
                 path
             )
             final = pd.read_csv(path)
-            self.assertEqual(len(final.columns), 18)
+            self.assertEqual(len(final.columns), 19)
             self.assertEqual(len(final), 1)
 
     @pytest.mark.fast
@@ -58,5 +58,5 @@ class TestFinal(unittest.TestCase):
                 path
             )
             final = pd.read_csv(path)
-            self.assertEqual(len(final.columns), 18)
+            self.assertEqual(len(final.columns), 19)
             self.assertEqual(len(final), 0)

--- a/sr-data/src/tests/test_snippets.py
+++ b/sr-data/src/tests/test_snippets.py
@@ -1,0 +1,54 @@
+"""
+Tests for snippets.
+"""
+# The MIT License (MIT)
+#
+# Copyright (c) 2024 Aliaksei Bialiauski
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+import unittest
+
+import pytest
+from sr_data.steps.snippets import snippets
+
+
+class TestSnippets(unittest.TestCase):
+
+    @pytest.mark.fast
+    def test_counts_snippets(self):
+        count = snippets("""
+        # test
+        ```bash
+        sh test1.sh
+        ```
+        
+        ```bash
+        sh test2.sh
+        ```
+        
+        ```bash
+        sh test3.sh
+        ```
+        """)
+        expected = 3
+        self.assertEqual(
+            count,
+            expected,
+            f"Found {count} snippets, but it does not match with expected: {expected}"
+        )

--- a/sr-data/src/tests/test_snippets.py
+++ b/sr-data/src/tests/test_snippets.py
@@ -1,6 +1,7 @@
 """
 Tests for snippets.
 """
+import os.path
 # The MIT License (MIT)
 #
 # Copyright (c) 2024 Aliaksei Bialiauski
@@ -23,9 +24,11 @@ Tests for snippets.
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 import unittest
+from tempfile import TemporaryDirectory
 
+import pandas as pd
 import pytest
-from sr_data.steps.snippets import snippets
+from sr_data.steps.snippets import snippets, main
 
 
 class TestSnippets(unittest.TestCase):
@@ -60,3 +63,17 @@ class TestSnippets(unittest.TestCase):
             0,
             "Found snippets should be equal to zero, but it was not"
         )
+
+    @pytest.mark.fast
+    def test_counts_snippets_for_all(self):
+        with TemporaryDirectory() as temp:
+            path = os.path.join(temp, "snippets.csv")
+            main(
+                os.path.join(
+                    os.path.dirname(os.path.realpath(__file__)), "to-snippets.csv"
+                ),
+                path
+            )
+            frame = pd.read_csv(path)
+            self.assertEqual(frame.iloc[0]["snippets"], 0)
+            self.assertEqual(frame.iloc[1]["snippets"], 16)

--- a/sr-data/src/tests/test_snippets.py
+++ b/sr-data/src/tests/test_snippets.py
@@ -52,3 +52,11 @@ class TestSnippets(unittest.TestCase):
             expected,
             f"Found {count} snippets, but it does not match with expected: {expected}"
         )
+
+    @pytest.mark.fast
+    def test_returns_zero_for_no_snippets(self):
+        self.assertEqual(
+            snippets("no snippets"),
+            0,
+            "Found snippets should be equal to zero, but it was not"
+        )

--- a/sr-data/src/tests/to-final-empty.csv
+++ b/sr-data/src/tests/to-final-empty.csv
@@ -1,1 +1,1 @@
-repo,branch,readme,releases,issues,branches,pulls,headings,top,projects,plugins,pwars,pjars,ppoms,hnum,rlen,avg_slen,avg_wlen,mcw,example_wc,sample_wc,demonstration_wc
+repo,branch,readme,releases,issues,branches,pulls,headings,top,projects,plugins,pwars,pjars,ppoms,hnum,rlen,avg_slen,avg_wlen,mcw,example_wc,sample_wc,demonstration_wc,snippets

--- a/sr-data/src/tests/to-final.csv
+++ b/sr-data/src/tests/to-final.csv
@@ -1,2 +1,2 @@
-repo,branch,readme,releases,issues,branches,pulls,headings,top,projects,plugins,pwars,pjars,ppoms,hnum,rlen,avg_slen,avg_wlen,mcw,example_wc,sample_wc,demonstration_wc
-foo/bar,master,# fake,1,2,3,4,"['fake']","['fake']",2,[org.springframework.boot:spring-boot-maven-plugin],0,1,1,1,2,1,2.2,"['fake']",1,2,3
+repo,branch,readme,releases,issues,branches,pulls,headings,top,projects,plugins,pwars,pjars,ppoms,hnum,rlen,avg_slen,avg_wlen,mcw,example_wc,sample_wc,demonstration_wc,snippets
+foo/bar,master,# fake,1,2,3,4,"['fake']","['fake']",2,[org.springframework.boot:spring-boot-maven-plugin],0,1,1,1,2,1,2.2,"['fake']",1,2,3,15

--- a/sr-data/src/tests/to-snippets.csv
+++ b/sr-data/src/tests/to-snippets.csv
@@ -1,0 +1,416 @@
+repo,readme
+foo/foo,"# myinvois-open-sdk
+
+Open source effort for MyInvois API.
+
+# Disclaimer
+
+While this software is provided under the terms of the Apache License, Version 2.0, it comes with no warranties or guarantees. Users are free to use, modify, and distribute the software according to the terms of the license. However, by using this software, users acknowledge that they do so at their own risk and assume all responsibility for any consequences that may arise from its use.
+
+# Current Status
+
+At the current state support:
+
+[JVM](jvm/) - Completed, login and validate TIN works, submit document to sandbox with and without signature is working.
+"
+foo/bar,"# Microservice micrometer log tracing
+
+I attempted to explain the libraries and some monitoring tools used to trace logs in projects written with a microservices architecture.
+
+## Technologies Used
+
+* Java 17
+* Springboot 3
+* Feign Client
+* Apache Kafka
+* Swagger
+* H2 Database
+* Zipkin
+* Grafana
+* Mapstruct
+* Micrometer
+
+## Architecture Diagram
+
+![architecture](Images/arch.png)
+
+## Running on Your Computer
+
+Clone the project
+
+```bash
+https://github.com/ErayMert/microservice-log-tracing.git
+```
+
+Navigate to the project directory in the terminal
+
+```bash
+  cd microservice-log-tracing
+```
+
+* The docker-compose.yml file contains configurations for Kafka, Grafana, Zipkin, Zookeeper, Tempo, and Loki.
+
+```yml
+version: '3.8'
+
+services:
+  grafana:
+    image: grafana/grafana-enterprise:latest
+    volumes:
+      - ./docker/grafana/datasources.yml:/etc/grafana/provisioning/datasources.yaml
+    environment:
+      - GF_AUTH_ANONYMOUS_ENABLED=true
+      - GF_AUTH_ANONYMOUS_ORG_ROLE=Admin
+      - GF_AUTH_DISABLE_LOGIN_FORM=true
+    ports:
+      - ""3000:3000""
+
+  zipkin:
+    image: openzipkin/zipkin:latest
+    ports:
+      - ""9411:9411""
+
+  zookeeper:
+    image: docker.io/bitnami/zookeeper:3.8
+    restart: always
+    hostname: zookeeper
+    container_name: zookeeper
+    ports:
+      - ""2181:2181""
+    environment:
+      ZOOKEEPER_CLIENT_PORT: 2181
+      ZOOKEEPER_TICK_TIME: 2000
+      ALLOW_ANONYMOUS_LOGIN: yes
+
+  kafka:
+    image: wurstmeister/kafka
+    container_name: kafka
+    ports:
+      - ""9092:9092""
+    environment:
+      KAFKA_ADVERTISED_HOST_NAME: localhost
+      KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
+
+  loki:
+    image: grafana/loki:main
+    command: [ ""-config.file=/etc/loki/local-config.yaml"" ]
+    ports:
+      - ""3100:3100""
+
+  tempo:
+    image: grafana/tempo:2.2.4
+    command: [ ""--target=all"", ""--storage.trace.backend=local"", ""--storage.trace.local.path=/var/tempo"", ""--auth.enabled=false"" ]
+    ports:
+      - ""14250:14250""
+      - ""4317:4317""
+    depends_on:
+      - loki
+```
+
+You can start these tools with the following command:
+
+```docker
+  docker-compose up -d
+```
+
+## Added Libraries
+
+* Brave is a library that enables tracing in distributed systems. Especially useful in complex systems like microservices architectures, it tracks requests passing through gateways, allowing you to see how requests interact with each other and how they are responded to.
+
+```xml
+<dependency>
+    <groupId>io.micrometer</groupId>
+    <artifactId>micrometer-tracing-bridge-brave</artifactId>
+</dependency>
+```
+
+* This dependency allows for the collection of metrics and monitoring via Micrometer in applications using OpenFeign.
+
+```xml
+<dependency>
+    <groupId>io.github.openfeign</groupId>
+    <artifactId>feign-micrometer</artifactId>
+</dependency>
+```
+
+* Zipkin is a tracing system and server that provides tracing and debugging capabilities in distributed systems. The zipkin-reporter-brave dependency provides the necessary reporter functionality to send reports to Zipkin via the Brave library, enabling tracing in your application through Zipkin.
+
+```xml
+<dependency>
+    <groupId>io.zipkin.reporter2</groupId>
+    <artifactId>zipkin-reporter-brave</artifactId>
+</dependency>
+```
+* Developed by Grafana Labs. The loki-logback-appender dependency allows for redirecting log messages from Logback to Loki. This enables storing your application's logs in Loki and visualizing them with Grafana.
+
+```xml
+<dependency>
+    <groupId>com.github.loki4j</groupId>
+    <artifactId>loki-logback-appender</artifactId>
+    <version>1.3.2</version>
+</dependency>
+```
+
+## Logback-spring.xml File
+
+* I configured the file as below since I'm tracing logs in Loki datasource in Grafana. This file should be present in every project.
+* The label sections correspond to the parts used for searching in Loki.
+
+```xml
+<?xml version=""1.0"" encoding=""UTF-8""?>
+<configuration>
+    <include resource=""org/springframework/boot/logging/logback/base.xml""/>
+    <springProperty scope=""context"" name=""appName"" source=""spring.application.name""/>
+
+    <appender name=""LOKI"" class=""com.github.loki4j.logback.Loki4jAppender"">
+        <http>
+            <url>http://localhost:3100/loki/api/v1/push</url>
+        </http>
+        <format>
+            <label>
+                <pattern>app=${appName},host=${HOSTNAME},traceID=%X{traceId:-NONE},level=%level</pattern>
+            </label>
+            <message>
+                <pattern>${FILE_LOG_PATTERN}</pattern>
+            </message>
+            <sortByTime>true</sortByTime>
+        </format>
+    </appender>
+
+    <root level=""INFO"">
+        <appender-ref ref=""LOKI""/>
+    </root>
+
+</configuration>
+```
+
+## Configuration in application.yml
+
+* The following setting indicates that all tracing data will be collected. That is, each request is traced and stored with a 100% probability.
+``` yml
+management:
+  tracing:
+    sampling:
+      probability: 1.0
+```
+* This setting provides Zipkin configuration and allows Spring Boot 3 to connect to a remote server.
+* By default `http://localhost:9411/api/v2/spans`, we don't need to specify the endpoint, but we need to for a standalone server.
+
+``` yml
+management:
+  zipkin:
+    tracing:
+      endpoint: ""http://localhost:9411/api/v2/spans""
+```
+* The following config specifies how the traceId and spanId will be reflected in the output.
+
+``` yml
+logging:
+  pattern:
+    level: ""%5p [${spring.application.name:},%X{traceId:-},%X{spanId:-}]""
+```
+
+* The output in the console looks like this:
+
+![trace_span](Images/trace_span.png)
+
+## Micrometer for Schedule
+
+* You must use version of spring boot above 3.2.0
+> https://github.com/spring-projects/spring-boot/issues/36119
+
+
+## Micrometer Configuration for Kafka
+
+* For the Producer:
+    * Set `kafkaTemplate.setMicrometerEnabled(true);`
+    * Set `kafkaTemplate.setObservationEnabled(true);`
+
+```java
+@RequiredArgsConstructor
+@Configuration
+public class ProducerConfiguration {
+
+    private final KafkaProperties kafkaProperties;
+
+    @Bean
+    public ProducerFactory<String, Object> producerFactory() {
+        Map<String, Object> configProps = new HashMap<>();
+        configProps.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, kafkaProperties.getAddress());
+        configProps.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+        configProps.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, JsonSerializer.class);
+
+        return new DefaultKafkaProducerFactory<>(configProps);
+    }
+
+    @Bean
+    public KafkaTemplate<String, Object> kafkaTemplate() {
+
+        KafkaTemplate<String, Object> kafkaTemplate = new KafkaTemplate<>(producerFactory());
+        kafkaTemplate.setMicrometerEnabled(true);
+        kafkaTemplate.setObservationEnabled(true);
+
+        return kafkaTemplate;
+    }
+}
+```
+
+* For the Consumer:
+    * Set `factory.getContainerProperties().setObservationEnabled(true);`
+    * Set `factory.getContainerProperties().setMicrometerEnabled(true);`
+    * Set `factory.getContainerProperties().setLogContainerConfig(true);` // Not required
+    * Set `factory.getContainerProperties().setCommitLogLevel(LogIfLevelEnabled.Level.INFO);`  // Not required
+
+```java
+@Slf4j
+@RequiredArgsConstructor
+@Configuration
+public class KafkaConsumerConfiguration {
+
+    private final KafkaProperties kafkaProperties;
+
+    @Bean
+    public KafkaListenerContainerFactory<ConcurrentMessageListenerContainer<String, Object>> kafkaListenerContainerFactory() {
+        ConcurrentKafkaListenerContainerFactory<String, Object> factory =
+                new ConcurrentKafkaListenerContainerFactory<>();
+
+        factory.getContainerProperties().setObservationEnabled(true);
+        factory.getContainerProperties().setMicrometerEnabled(true);
+        factory.getContainerProperties().setLogContainerConfig(true);
+        factory.getContainerProperties().setCommitLogLevel(LogIfLevelEnabled.Level.INFO);
+        factory.setConsumerFactory(new DefaultKafkaConsumerFactory<>(consumerConfigs()));
+        return factory;
+    }
+
+    @Bean
+    public Map<String, Object> consumerConfigs() {
+        Map<String, Object> props = new HashMap<>();
+        props.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, kafkaProperties.getAddress());
+        props.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+        props.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, JsonDeserializer.class);
+        props.put(ConsumerConfig.GROUP_ID_CONFIG, kafkaProperties.getGroupId());
+        props.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, ""latest"");
+        props.put(JsonDeserializer.TRUSTED_PACKAGES, ""*"");
+        return props;
+    }
+
+}
+```
+
+## Micrometer Configuration for Async
+
+* By design you can only have one AsyncConfigurer, thus only one executor pool is
+
+```java
+import io.micrometer.context.ContextExecutorService;
+import io.micrometer.context.ContextSnapshot;
+import java.util.concurrent.Executor;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.AsyncConfigurer;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+@Configuration(proxyBeanMethods = false)
+@RequiredArgsConstructor
+public class AsyncTraceContextConfig implements AsyncConfigurer {
+
+  // NOTE: By design you can only have one AsyncConfigurer, thus only one executor pool is
+  // configurable.
+  @Qualifier(""taskExecutor"") // if you have more than one task executor pools
+  private final ThreadPoolTaskExecutor taskExecutor;
+
+  @Override
+  public Executor getAsyncExecutor() {
+    return ContextExecutorService.wrap(
+            taskExecutor.getThreadPoolExecutor(),
+                    ContextSnapshotFactory.builder().build()::captureAll);
+  }
+}
+```
+* If you have more than one executor pools and wants to add tracing to all, use the TaskDecorator with ContextSnapshot.wrap():
+
+```java
+import io.micrometer.context.ContextSnapshot;
+import java.util.concurrent.Executor;
+import org.springframework.boot.task.TaskExecutorBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.task.TaskDecorator;
+
+@Configuration
+public class AsyncConfig {
+  @Bean
+  public TaskDecorator otelTaskDecorator() {
+    return runnable -> ContextSnapshotFactory.builder().build()
+                                      .captureAll((new Object[0])).wrap(runnable);
+  }
+
+  @Bean(""asyncExecutorPool1"")
+  public Executor asyncExecutorPool1(TaskDecorator otelTaskDecorator) {
+    return new TaskExecutorBuilder()
+        .corePoolSize(5)
+        .maxPoolSize(10)
+        .queueCapacity(10)
+        .threadNamePrefix(""threadPoolExecutor1-"")
+        .taskDecorator(otelTaskDecorator)
+        .build();
+  }
+
+  @Bean(""asyncExecutorPool2"")
+  public Executor asyncExecutorPool2(TaskDecorator otelTaskDecorator) {
+    return new TaskExecutorBuilder()
+        .corePoolSize(5)
+        .maxPoolSize(10)
+        .queueCapacity(10)
+        .threadNamePrefix(""threadPoolExecutor2-"")
+        .taskDecorator(otelTaskDecorator)
+        .build();
+  }
+}
+```
+## Trying it out on the Application
+
+* First, let's create a customer and a product using Swagger.
+
+![create_customer](Images/create_customer.png)
+![create_product](Images/product_create.png)
+
+* Then, the customer will create an order, and the customer service will communicate with the order service via Kafka to create an order.
+![create_order](Images/create_order.png)
+
+### Log Tracing with Grafana
+
+* Connect to Grafana using the address <http://localhost:3000>
+* The configuration of logback-spring.xml on Loki datasource in Grafana looks like this:
+
+![loki label](Images/loki_label.png)
+
+* Let's observe the order creation we tried above on Grafana.
+  * First, we'll obtain a traceId from the customer service, and then we'll search on Loki using this traceId to observe all logs associated with this traceId.
+
+![create_order_log](Images/create_order_log.png)
+  * Let's search with the traceId we obtained, and we'll see all service logs associated with this traceId.
+
+![create_order_trace_log](Images/grafana_trace_log.png)
+
+### Log Tracing with Zipkin
+* To connect to Zipkin, use the address <http://localhost:9411>
+
+* If we observe the order creation request on Zipkin, we'll see output like this:
+
+![zipkin_trace_log](Images/zipkin_trace_log.png)
+
+
+### Happy coding, and may your microservices journey be filled with successful deployments and seamless operations!""
+
+
+
+
+
+
+
+
+
+
+"


### PR DESCRIPTION
In this pull I've implemented `snippets` step, that counts code snippets: "```" in README files.

closes #151
History:
- **feat(#151): start**
- **feat(#151): snippets**
- **feat(#151): test case**
- **feat(#151): zero count test case**
- **feat(#151): test case for all**
- **feat(#151): snippets in final**

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on adding functionality to count snippets in README files and integrates this feature into the existing data processing pipeline. It also includes tests for the new functionality and updates related CSV files to accommodate the changes.

### Detailed summary
- Added `snippets` functionality to count code snippets in README files.
- Updated `final.py` to include `snippets` in the output DataFrame.
- Created `snippets.py` with main logic for counting snippets.
- Added tests for `snippets` functionality in `test_snippets.py`.
- Updated CSV files to include a new `snippets` column.
- Modified workflow to incorporate the new `snippets` task.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->