### PR TITLE
feat(#152): links, links_count

### DIFF
--- a/.github/workflows/collect.yml
+++ b/.github/workflows/collect.yml
@@ -77,7 +77,8 @@ jobs:
             just maven "../after-snippets.csv" "$TOKEN" \
               "../after-maven.csv"
             just lens "../after-maven.csv" "../after-lens.csv"
-            just final "../after-lens.csv" "../final.csv"
+            just links "../after-lens.csv" "../after-links.csv"
+            just final "../after-links.csv" "../final.csv"
           } 2>&1 | tee -a collect.log
           sed -i "s|$TOKEN|REDACTED|g" collect.log
           mkdir -p "collection/${{ inputs.out }}/steps"
@@ -90,6 +91,7 @@ jobs:
           cp "after-snippets.csv" "collection/${{ inputs.out }}/steps/"
           cp "after-maven.csv" "collection/${{ inputs.out }}/steps/"
           cp "after-lens.csv" "collection/${{ inputs.out }}/steps/"
+          cp "after-links.csv" "collection/${{ inputs.out }}/steps/"
           cp "collect.log" "collection/${{ inputs.out }}"
           cp "final.csv" "collection/${{ inputs.out }}"
       - uses: JamesIves/github-pages-deploy-action@v4.6.8

--- a/justfile
+++ b/justfile
@@ -104,13 +104,17 @@ swc repos out="experiment/after-swc.csv" config="resources/swc-words.txt":
 lens repos out="experiment/after-lens.csv":
   cd sr-data && poetry poe lens --repos {{repos}} --out {{out}}
 
-# Compose all found metadata into final CSV.
-final latest out="experiment/final.csv":
-  cd sr-data && poetry poe final --latest {{latest}} --out {{out}}
-
 # Count snippets.
 snippets repos out="experiment/after-snippets.csv":
   cd sr-data && poetry poe snippets --repos {{repos}} --out {{out}}
+
+# Count links.
+links repos out="experiment/after-links.csv":
+  cd sr-data && poetry poe links --repos {{repos}} --out {{out}}
+
+# Compose all found metadata into final CSV.
+final latest out="experiment/final.csv":
+  cd sr-data && poetry poe final --latest {{latest}} --out {{out}}
 
 # Create embeddings.
 embed repos prefix="experiment/embeddings":

--- a/sr-data/pyproject.toml
+++ b/sr-data/pyproject.toml
@@ -113,6 +113,10 @@ args = [{name = "latest"}, {name = "out"}]
 script = "sr_data.steps.snippets:main(repos, out)"
 args = [{name = "repos"}, {name = "out"}]
 
+[tool.poe.tasks.links]
+script = "sr_data.steps.links:main(repos, out)"
+args = [{name = "repos"}, {name = "out"}]
+
 [build-system]
 requires = ["setuptools", "wheel"]
 build-backend = "setuptools.build_meta"

--- a/sr-data/src/sr_data/steps/final.py
+++ b/sr-data/src/sr_data/steps/final.py
@@ -47,7 +47,9 @@ def main(latest, out):
             "avg_slen",
             "avg_wlen",
             "hnum",
-            "snippets"
+            "snippets",
+            "links_count",
+            "links"
         ]
     ]
     frame.to_csv(out, index=False)

--- a/sr-data/src/sr_data/steps/links.py
+++ b/sr-data/src/sr_data/steps/links.py
@@ -31,22 +31,23 @@ from loguru import logger
 def main(repos, out):
     frame = pd.read_csv(repos)
     logger.info(f"Counting links in {len(frame)} repositories")
-    frame["links"] = frame["readme"].apply(links_count)
+    frame["links"] = frame["readme"].apply(links)
+    frame["links_count"] = frame["links"].apply(len)
     frame.to_csv(out, index=False)
     logger.info(f"Saved {len(frame)} repositories to {out}")
 
 
-def links_count(readme):
+def links(readme):
+    found = []
     http = re.findall(r"\[(.*?)]\((http[s]?://.*?)\)", readme)
-    links = []
     for text, url in http:
         if url:
-            links.append(f"{text} -> {url}")
-    aliased = re.findall(r"\[(.+?)\](?:\[\s*(.*?)\s*\]|(?!\s*\(.*?\)))", readme)
+            found.append(f"{text} -> {url}")
+    aliased = re.findall(r"\[(.+?)](?:\[\s*(.*?)\s*]|(?!\s*\(.*?\)))", readme)
     for text, alias in aliased:
         if re.match(r"^(?![0-9]+$)[\w\s]+$", text):
             if alias:
-                links.append(f"{text} -> {alias}")
+                found.append(f"{text} -> {alias}")
             else:
-                links.append(text)
-    return len(links)
+                found.append(text)
+    return found

--- a/sr-data/src/sr_data/steps/links.py
+++ b/sr-data/src/sr_data/steps/links.py
@@ -31,12 +31,12 @@ from loguru import logger
 def main(repos, out):
     frame = pd.read_csv(repos)
     logger.info(f"Counting links in {len(frame)} repositories")
-    frame["links"] = frame["readme"].apply(links)
+    frame["links"] = frame["readme"].apply(links_count)
     frame.to_csv(out, index=False)
     logger.info(f"Saved {len(frame)} repositories to {out}")
 
 
-def links(readme):
+def links_count(readme):
     http = re.findall(r"\[(.*?)]\((http[s]?://.*?)\)", readme)
     links = []
     for text, url in http:

--- a/sr-data/src/sr_data/steps/links.py
+++ b/sr-data/src/sr_data/steps/links.py
@@ -42,10 +42,11 @@ def links_count(readme):
     for text, url in http:
         if url:
             links.append(f"{text} -> {url}")
-    aliased = re.findall(r"\[(.*?)](?!\s*\(.*?\))(?:\[\s*(.*?)\s*\]|$)", readme)
+    aliased = re.findall(r"\[(.+?)\](?:\[\s*(.*?)\s*\]|(?!\s*\(.*?\)))", readme)
     for text, alias in aliased:
-        if alias:
-            links.append(f"{text} -> {alias}")
-        else:
-            links.append(text)
+        if re.match(r"^(?![0-9]+$)[\w\s]+$", text):
+            if alias:
+                links.append(f"{text} -> {alias}")
+            else:
+                links.append(text)
     return len(links)

--- a/sr-data/src/sr_data/steps/links.py
+++ b/sr-data/src/sr_data/steps/links.py
@@ -1,0 +1,37 @@
+"""
+Links count in READMEs.
+"""
+# The MIT License (MIT)
+#
+# Copyright (c) 2024 Aliaksei Bialiauski
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+import pandas as pd
+from loguru import logger
+
+
+def main(repos, out):
+    frame = pd.read_csv(repos)
+    logger.info(f"Counting links in {len(frame)} repositories")
+    frame["links"] = frame["readme"].apply(links)
+    frame.to_csv(out, index=False)
+    logger.info(f"Saved {len(frame)} repositories to {out}")
+
+def links(readme):
+    return 0

--- a/sr-data/src/sr_data/steps/links.py
+++ b/sr-data/src/sr_data/steps/links.py
@@ -22,6 +22,8 @@ Links count in READMEs.
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
+import re
+
 import pandas as pd
 from loguru import logger
 
@@ -33,5 +35,17 @@ def main(repos, out):
     frame.to_csv(out, index=False)
     logger.info(f"Saved {len(frame)} repositories to {out}")
 
+
 def links(readme):
-    return 0
+    http = re.findall(r"\[(.*?)]\((http[s]?://.*?)\)", readme)
+    links = []
+    for text, url in http:
+        if url:
+            links.append(f"{text} -> {url}")
+    aliased = re.findall(r"\[(.*?)](?!\s*\(.*?\))(?:\[\s*(.*?)\s*\]|$)", readme)
+    for text, alias in aliased:
+        if alias:
+            links.append(f"{text} -> {alias}")
+        else:
+            links.append(text)
+    return len(links)

--- a/sr-data/src/tests/test_final.py
+++ b/sr-data/src/tests/test_final.py
@@ -44,7 +44,7 @@ class TestFinal(unittest.TestCase):
                 path
             )
             final = pd.read_csv(path)
-            self.assertEqual(len(final.columns), 19)
+            self.assertEqual(len(final.columns), 21)
             self.assertEqual(len(final), 1)
 
     @pytest.mark.fast
@@ -58,5 +58,5 @@ class TestFinal(unittest.TestCase):
                 path
             )
             final = pd.read_csv(path)
-            self.assertEqual(len(final.columns), 19)
+            self.assertEqual(len(final.columns), 21)
             self.assertEqual(len(final), 0)

--- a/sr-data/src/tests/test_links.py
+++ b/sr-data/src/tests/test_links.py
@@ -79,5 +79,5 @@ class TestLinks(unittest.TestCase):
             frame = pd.read_csv(path)
             self.assertEqual(
                 frame.iloc[0]["links"],
-                4
+                2
             )

--- a/sr-data/src/tests/test_links.py
+++ b/sr-data/src/tests/test_links.py
@@ -28,14 +28,14 @@ from tempfile import TemporaryDirectory
 
 import pandas as pd
 import pytest
-from sr_data.steps.links import links_count, main
+from sr_data.steps.links import links, main
 
 
 class TestLinks(unittest.TestCase):
 
     @pytest.mark.fast
     def test_counts_links(self):
-        count = links_count(
+        found = links(
             """
         [HTTP](http://test.com)
         [HTTPS](https://test.com)
@@ -43,27 +43,32 @@ class TestLinks(unittest.TestCase):
         [Inline]
         """
         )
-        expected = 4
+        expected = [
+            "HTTP -> http://test.com",
+            "HTTPS -> https://test.com",
+            "Alias -> here",
+            "Inline"
+        ]
         self.assertEqual(
-            count,
+            found,
             expected,
-            f"Links count: {count} does not match with expected: {expected}"
+            f"Links: {found} does not match with expected: {expected}"
         )
 
     @pytest.mark.fast
     def test_skips_document_level_links(self):
-        count = links_count(
+        found = links(
             """
             [Good](https://good.link)
             [Anchor in the document](#here)
             [Heading in the document](/here)
             """
         )
-        expected = 1
+        expected = ["Good -> https://good.link"]
         self.assertEqual(
-            count,
+            found,
             expected,
-            f"Links count: {count} does not match with expected: {expected}"
+            f"Links: {found} do not match with expected: {expected}"
         )
 
     @pytest.mark.fast
@@ -79,5 +84,9 @@ class TestLinks(unittest.TestCase):
             frame = pd.read_csv(path)
             self.assertEqual(
                 frame.iloc[0]["links"],
+                "['Test', 'Test2 -> ref']"
+            )
+            self.assertEqual(
+                frame.iloc[0]["links_count"],
                 2
             )

--- a/sr-data/src/tests/test_links.py
+++ b/sr-data/src/tests/test_links.py
@@ -1,0 +1,83 @@
+"""
+Tests for links.
+"""
+import os.path
+# The MIT License (MIT)
+#
+# Copyright (c) 2024 Aliaksei Bialiauski
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+import unittest
+from tempfile import TemporaryDirectory
+
+import pandas as pd
+import pytest
+from sr_data.steps.links import links_count, main
+
+
+class TestLinks(unittest.TestCase):
+
+    @pytest.mark.fast
+    def test_counts_links(self):
+        count = links_count(
+            """
+        [HTTP](http://test.com)
+        [HTTPS](https://test.com)
+        [Alias][here]
+        [Inline]
+        """
+        )
+        expected = 4
+        self.assertEqual(
+            count,
+            expected,
+            f"Links count: {count} does not match with expected: {expected}"
+        )
+
+    @pytest.mark.fast
+    def test_skips_document_level_links(self):
+        count = links_count(
+            """
+            [Good](https://good.link)
+            [Anchor in the document](#here)
+            [Heading in the document](/here)
+            """
+        )
+        expected = 1
+        self.assertEqual(
+            count,
+            expected,
+            f"Links count: {count} does not match with expected: {expected}"
+        )
+
+    @pytest.mark.fast
+    def test_counts_for_all(self):
+        with TemporaryDirectory() as temp:
+            path = os.path.join(temp, "links.csv")
+            main(
+                os.path.join(
+                    os.path.dirname(os.path.realpath(__file__)), "to-links.csv"
+                ),
+                path
+            )
+            frame = pd.read_csv(path)
+            self.assertEqual(
+                frame.iloc[0]["links"],
+                4
+            )

--- a/sr-data/src/tests/to-final-empty.csv
+++ b/sr-data/src/tests/to-final-empty.csv
@@ -1,1 +1,1 @@
-repo,branch,readme,releases,issues,branches,pulls,headings,top,projects,plugins,pwars,pjars,ppoms,hnum,rlen,avg_slen,avg_wlen,mcw,example_wc,sample_wc,demonstration_wc,snippets
+repo,branch,readme,releases,issues,branches,pulls,headings,top,projects,plugins,pwars,pjars,ppoms,hnum,rlen,avg_slen,avg_wlen,mcw,example_wc,sample_wc,demonstration_wc,snippets,links,links_count

--- a/sr-data/src/tests/to-final.csv
+++ b/sr-data/src/tests/to-final.csv
@@ -1,2 +1,2 @@
-repo,branch,readme,releases,issues,branches,pulls,headings,top,projects,plugins,pwars,pjars,ppoms,hnum,rlen,avg_slen,avg_wlen,mcw,example_wc,sample_wc,demonstration_wc,snippets
-foo/bar,master,# fake,1,2,3,4,"['fake']","['fake']",2,[org.springframework.boot:spring-boot-maven-plugin],0,1,1,1,2,1,2.2,"['fake']",1,2,3,15
+repo,branch,readme,releases,issues,branches,pulls,headings,top,projects,plugins,pwars,pjars,ppoms,hnum,rlen,avg_slen,avg_wlen,mcw,example_wc,sample_wc,demonstration_wc,snippets,links,links_count
+foo/bar,master,# fake,1,2,3,4,"['fake']","['fake']",2,[org.springframework.boot:spring-boot-maven-plugin],0,1,1,1,2,1,2.2,"['fake']",1,2,3,15,"['example -> https://example.com']",1

--- a/sr-data/src/tests/to-links.csv
+++ b/sr-data/src/tests/to-links.csv
@@ -1,0 +1,403 @@
+repo,readme
+foo/bar,"[Test]
+[Test2][ref]
+# Microservice micrometer log tracing
+I attempted to explain the libraries and some monitoring tools used to trace logs in projects written with a microservices architecture.
+
+## Technologies Used
+
+* Java 17
+* Springboot 3
+* Feign Client
+* Apache Kafka
+* Swagger
+* H2 Database
+* Zipkin
+* Grafana
+* Mapstruct
+* Micrometer
+
+## Architecture Diagram
+
+![architecture](Images/arch.png)
+
+## Running on Your Computer
+
+Clone the project
+
+```bash
+https://github.com/ErayMert/microservice-log-tracing.git
+```
+
+Navigate to the project directory in the terminal
+
+```bash
+  cd microservice-log-tracing
+```
+
+* The docker-compose.yml file contains configurations for Kafka, Grafana, Zipkin, Zookeeper, Tempo, and Loki.
+
+```yml
+version: '3.8'
+
+services:
+  grafana:
+    image: grafana/grafana-enterprise:latest
+    volumes:
+      - ./docker/grafana/datasources.yml:/etc/grafana/provisioning/datasources.yaml
+    environment:
+      - GF_AUTH_ANONYMOUS_ENABLED=true
+      - GF_AUTH_ANONYMOUS_ORG_ROLE=Admin
+      - GF_AUTH_DISABLE_LOGIN_FORM=true
+    ports:
+      - ""3000:3000""
+
+  zipkin:
+    image: openzipkin/zipkin:latest
+    ports:
+      - ""9411:9411""
+
+  zookeeper:
+    image: docker.io/bitnami/zookeeper:3.8
+    restart: always
+    hostname: zookeeper
+    container_name: zookeeper
+    ports:
+      - ""2181:2181""
+    environment:
+      ZOOKEEPER_CLIENT_PORT: 2181
+      ZOOKEEPER_TICK_TIME: 2000
+      ALLOW_ANONYMOUS_LOGIN: yes
+
+  kafka:
+    image: wurstmeister/kafka
+    container_name: kafka
+    ports:
+      - ""9092:9092""
+    environment:
+      KAFKA_ADVERTISED_HOST_NAME: localhost
+      KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
+
+  loki:
+    image: grafana/loki:main
+    command: [ ""-config.file=/etc/loki/local-config.yaml"" ]
+    ports:
+      - ""3100:3100""
+
+  tempo:
+    image: grafana/tempo:2.2.4
+    command: [ ""--target=all"", ""--storage.trace.backend=local"", ""--storage.trace.local.path=/var/tempo"", ""--auth.enabled=false"" ]
+    ports:
+      - ""14250:14250""
+      - ""4317:4317""
+    depends_on:
+      - loki
+```
+
+You can start these tools with the following command:
+
+```docker
+  docker-compose up -d
+```
+
+## Added Libraries
+
+* Brave is a library that enables tracing in distributed systems. Especially useful in complex systems like microservices architectures, it tracks requests passing through gateways, allowing you to see how requests interact with each other and how they are responded to.
+
+```xml
+<dependency>
+    <groupId>io.micrometer</groupId>
+    <artifactId>micrometer-tracing-bridge-brave</artifactId>
+</dependency>
+```
+
+* This dependency allows for the collection of metrics and monitoring via Micrometer in applications using OpenFeign.
+
+```xml
+<dependency>
+    <groupId>io.github.openfeign</groupId>
+    <artifactId>feign-micrometer</artifactId>
+</dependency>
+```
+
+* Zipkin is a tracing system and server that provides tracing and debugging capabilities in distributed systems. The zipkin-reporter-brave dependency provides the necessary reporter functionality to send reports to Zipkin via the Brave library, enabling tracing in your application through Zipkin.
+
+```xml
+<dependency>
+    <groupId>io.zipkin.reporter2</groupId>
+    <artifactId>zipkin-reporter-brave</artifactId>
+</dependency>
+```
+* Developed by Grafana Labs. The loki-logback-appender dependency allows for redirecting log messages from Logback to Loki. This enables storing your application's logs in Loki and visualizing them with Grafana.
+
+```xml
+<dependency>
+    <groupId>com.github.loki4j</groupId>
+    <artifactId>loki-logback-appender</artifactId>
+    <version>1.3.2</version>
+</dependency>
+```
+
+## Logback-spring.xml File
+
+* I configured the file as below since I'm tracing logs in Loki datasource in Grafana. This file should be present in every project.
+* The label sections correspond to the parts used for searching in Loki.
+
+```xml
+<?xml version=""1.0"" encoding=""UTF-8""?>
+<configuration>
+    <include resource=""org/springframework/boot/logging/logback/base.xml""/>
+    <springProperty scope=""context"" name=""appName"" source=""spring.application.name""/>
+
+    <appender name=""LOKI"" class=""com.github.loki4j.logback.Loki4jAppender"">
+        <http>
+            <url>http://localhost:3100/loki/api/v1/push</url>
+        </http>
+        <format>
+            <label>
+                <pattern>app=${appName},host=${HOSTNAME},traceID=%X{traceId:-NONE},level=%level</pattern>
+            </label>
+            <message>
+                <pattern>${FILE_LOG_PATTERN}</pattern>
+            </message>
+            <sortByTime>true</sortByTime>
+        </format>
+    </appender>
+
+    <root level=""INFO"">
+        <appender-ref ref=""LOKI""/>
+    </root>
+
+</configuration>
+```
+
+## Configuration in application.yml
+
+* The following setting indicates that all tracing data will be collected. That is, each request is traced and stored with a 100% probability.
+``` yml
+management:
+  tracing:
+    sampling:
+      probability: 1.0
+```
+* This setting provides Zipkin configuration and allows Spring Boot 3 to connect to a remote server.
+* By default `http://localhost:9411/api/v2/spans`, we don't need to specify the endpoint, but we need to for a standalone server.
+
+``` yml
+management:
+  zipkin:
+    tracing:
+      endpoint: ""http://localhost:9411/api/v2/spans""
+```
+* The following config specifies how the traceId and spanId will be reflected in the output.
+
+``` yml
+logging:
+  pattern:
+    level: ""%5p [${spring.application.name:},%X{traceId:-},%X{spanId:-}]""
+```
+
+* The output in the console looks like this:
+
+![trace_span](Images/trace_span.png)
+
+## Micrometer for Schedule
+
+* You must use version of spring boot above 3.2.0
+> https://github.com/spring-projects/spring-boot/issues/36119
+
+
+## Micrometer Configuration for Kafka
+
+* For the Producer:
+    * Set `kafkaTemplate.setMicrometerEnabled(true);`
+    * Set `kafkaTemplate.setObservationEnabled(true);`
+
+```java
+@RequiredArgsConstructor
+@Configuration
+public class ProducerConfiguration {
+
+    private final KafkaProperties kafkaProperties;
+
+    @Bean
+    public ProducerFactory<String, Object> producerFactory() {
+        Map<String, Object> configProps = new HashMap<>();
+        configProps.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, kafkaProperties.getAddress());
+        configProps.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+        configProps.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, JsonSerializer.class);
+
+        return new DefaultKafkaProducerFactory<>(configProps);
+    }
+
+    @Bean
+    public KafkaTemplate<String, Object> kafkaTemplate() {
+
+        KafkaTemplate<String, Object> kafkaTemplate = new KafkaTemplate<>(producerFactory());
+        kafkaTemplate.setMicrometerEnabled(true);
+        kafkaTemplate.setObservationEnabled(true);
+
+        return kafkaTemplate;
+    }
+}
+```
+
+* For the Consumer:
+    * Set `factory.getContainerProperties().setObservationEnabled(true);`
+    * Set `factory.getContainerProperties().setMicrometerEnabled(true);`
+    * Set `factory.getContainerProperties().setLogContainerConfig(true);` // Not required
+    * Set `factory.getContainerProperties().setCommitLogLevel(LogIfLevelEnabled.Level.INFO);`  // Not required
+
+```java
+@Slf4j
+@RequiredArgsConstructor
+@Configuration
+public class KafkaConsumerConfiguration {
+
+    private final KafkaProperties kafkaProperties;
+
+    @Bean
+    public KafkaListenerContainerFactory<ConcurrentMessageListenerContainer<String, Object>> kafkaListenerContainerFactory() {
+        ConcurrentKafkaListenerContainerFactory<String, Object> factory =
+                new ConcurrentKafkaListenerContainerFactory<>();
+
+        factory.getContainerProperties().setObservationEnabled(true);
+        factory.getContainerProperties().setMicrometerEnabled(true);
+        factory.getContainerProperties().setLogContainerConfig(true);
+        factory.getContainerProperties().setCommitLogLevel(LogIfLevelEnabled.Level.INFO);
+        factory.setConsumerFactory(new DefaultKafkaConsumerFactory<>(consumerConfigs()));
+        return factory;
+    }
+
+    @Bean
+    public Map<String, Object> consumerConfigs() {
+        Map<String, Object> props = new HashMap<>();
+        props.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, kafkaProperties.getAddress());
+        props.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+        props.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, JsonDeserializer.class);
+        props.put(ConsumerConfig.GROUP_ID_CONFIG, kafkaProperties.getGroupId());
+        props.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, ""latest"");
+        props.put(JsonDeserializer.TRUSTED_PACKAGES, ""*"");
+        return props;
+    }
+
+}
+```
+
+## Micrometer Configuration for Async
+
+* By design you can only have one AsyncConfigurer, thus only one executor pool is
+
+```java
+import io.micrometer.context.ContextExecutorService;
+import io.micrometer.context.ContextSnapshot;
+import java.util.concurrent.Executor;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.AsyncConfigurer;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+@Configuration(proxyBeanMethods = false)
+@RequiredArgsConstructor
+public class AsyncTraceContextConfig implements AsyncConfigurer {
+
+  // NOTE: By design you can only have one AsyncConfigurer, thus only one executor pool is
+  // configurable.
+  @Qualifier(""taskExecutor"") // if you have more than one task executor pools
+  private final ThreadPoolTaskExecutor taskExecutor;
+
+  @Override
+  public Executor getAsyncExecutor() {
+    return ContextExecutorService.wrap(
+            taskExecutor.getThreadPoolExecutor(),
+                    ContextSnapshotFactory.builder().build()::captureAll);
+  }
+}
+```
+* If you have more than one executor pools and wants to add tracing to all, use the TaskDecorator with ContextSnapshot.wrap():
+
+```java
+import io.micrometer.context.ContextSnapshot;
+import java.util.concurrent.Executor;
+import org.springframework.boot.task.TaskExecutorBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.task.TaskDecorator;
+
+@Configuration
+public class AsyncConfig {
+  @Bean
+  public TaskDecorator otelTaskDecorator() {
+    return runnable -> ContextSnapshotFactory.builder().build()
+                                      .captureAll((new Object[0])).wrap(runnable);
+  }
+
+  @Bean(""asyncExecutorPool1"")
+  public Executor asyncExecutorPool1(TaskDecorator otelTaskDecorator) {
+    return new TaskExecutorBuilder()
+        .corePoolSize(5)
+        .maxPoolSize(10)
+        .queueCapacity(10)
+        .threadNamePrefix(""threadPoolExecutor1-"")
+        .taskDecorator(otelTaskDecorator)
+        .build();
+  }
+
+  @Bean(""asyncExecutorPool2"")
+  public Executor asyncExecutorPool2(TaskDecorator otelTaskDecorator) {
+    return new TaskExecutorBuilder()
+        .corePoolSize(5)
+        .maxPoolSize(10)
+        .queueCapacity(10)
+        .threadNamePrefix(""threadPoolExecutor2-"")
+        .taskDecorator(otelTaskDecorator)
+        .build();
+  }
+}
+```
+## Trying it out on the Application
+
+* First, let's create a customer and a product using Swagger.
+
+![create_customer](Images/create_customer.png)
+![create_product](Images/product_create.png)
+
+* Then, the customer will create an order, and the customer service will communicate with the order service via Kafka to create an order.
+![create_order](Images/create_order.png)
+
+### Log Tracing with Grafana
+
+* Connect to Grafana using the address <http://localhost:3000>
+* The configuration of logback-spring.xml on Loki datasource in Grafana looks like this:
+
+![loki label](Images/loki_label.png)
+
+* Let's observe the order creation we tried above on Grafana.
+  * First, we'll obtain a traceId from the customer service, and then we'll search on Loki using this traceId to observe all logs associated with this traceId.
+
+![create_order_log](Images/create_order_log.png)
+  * Let's search with the traceId we obtained, and we'll see all service logs associated with this traceId.
+
+![create_order_trace_log](Images/grafana_trace_log.png)
+
+### Log Tracing with Zipkin
+* To connect to Zipkin, use the address <http://localhost:9411>
+
+* If we observe the order creation request on Zipkin, we'll see output like this:
+
+![zipkin_trace_log](Images/zipkin_trace_log.png)
+
+
+### Happy coding, and may your microservices journey be filled with successful deployments and seamless operations!""
+
+
+
+
+
+
+
+
+
+
+"


### PR DESCRIPTION
In this pull I've introduced new features: `links` (textual), and `links_count` (numerical).

closes #152
History:
- **feat(#152): start**
- **feat(#152): http, aliased**
- **feat(#152): links_count**
- **feat(#152): check matches**
- **feat(#152): test values**
- **feat(#152): links, links_count**
- **feat(#152): both**
- **chore(#152): after-links**

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enhancing the functionality of the `sr_data` package by adding link counting capabilities in README files, updating CSV outputs, and expanding test coverage for these new features.

### Detailed summary
- Added `links` and `links_count` to the CSV output in `final.py`.
- Implemented a new `links.py` script for counting links in README files.
- Created tests for the new `links` functionality in `test_links.py`.
- Updated `to-links.csv` with example data for testing.
- Modified workflow in `.github/workflows/collect.yml` to handle new links data.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->