### PR TITLE
fix(#174): pulls_count

### DIFF
--- a/sr-data/src/sr_data/steps/pulls.py
+++ b/sr-data/src/sr_data/steps/pulls.py
@@ -31,7 +31,7 @@ from requests import Response
 def main(repos, out, token):
     frame = pd.read_csv(repos)
     for idx, row in frame.iterrows():
-        frame.at[idx, "pulls"] = pulls(row["repo"], token)
+        frame.at[idx, "pulls_count"] = pulls(row["repo"], token)
     frame.to_csv(out, index=False)
 
 

--- a/sr-data/src/tests/test_pulls.py
+++ b/sr-data/src/tests/test_pulls.py
@@ -44,4 +44,4 @@ class TestPulls(unittest.TestCase):
                 path,
                 os.environ["GH_TESTING_TOKEN"]
             )
-            self.assertTrue("pulls" in pd.read_csv(path).columns)
+            self.assertTrue("pulls_count" in pd.read_csv(path).columns)


### PR DESCRIPTION
ref #174 

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the handling of pull request data by changing the column name from `pulls` to `pulls_count` in both the test and the data processing files.

### Detailed summary
- In `test_pulls.py`, changed the assertion to check for the presence of the `pulls_count` column instead of `pulls`.
- In `pulls.py`, updated the DataFrame assignment from `pulls` to `pulls_count` when populating the DataFrame with pull request data.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->