### PR TITLE
feat(#177): enumerate every step with id

### DIFF
--- a/.github/workflows/collect.yml
+++ b/.github/workflows/collect.yml
@@ -82,17 +82,24 @@ jobs:
           } 2>&1 | tee -a collect.log
           sed -i "s|$TOKEN|REDACTED|g" collect.log
           mkdir -p "collection/${{ inputs.out }}/steps"
-          cp "repos.csv" "collection/${{ inputs.out }}/steps/"
-          cp "repos-with-pulls.csv" "collection/${{ inputs.out }}/steps/"
-          cp "after-filter.csv" "collection/${{ inputs.out }}/steps/"
-          cp "after-mcw.csv" "collection/${{ inputs.out }}/steps/"
-          cp "after-swc.csv" "collection/${{ inputs.out }}/steps/"
-          cp "after-extract.csv" "collection/${{ inputs.out }}/steps/"
-          cp "after-snippets.csv" "collection/${{ inputs.out }}/steps/"
-          cp "after-maven.csv" "collection/${{ inputs.out }}/steps/"
-          cp "after-junit.csv" "collection/${{ inputs.out }}/steps/"
-          cp "after-lens.csv" "collection/${{ inputs.out }}/steps/"
-          cp "after-links.csv" "collection/${{ inputs.out }}/steps/"
+          files=(
+            "repos.csv"
+            "repos-with-pulls.csv"
+            "after-filter.csv"
+            "after-mcw.csv"
+            "after-swc.csv"
+            "after-extract.csv"
+            "after-snippets.csv"
+            "after-maven.csv"
+            "after-junit.csv"
+            "after-lens.csv"
+            "after-links.csv"
+          )
+          id=1
+          for file in "${files[@]}"; do
+            cp "$file" "collections/${{ inputs.out }}/steps/$(printf '%02d' $i)-$file"
+            i=$((i+1))
+          done
           cp "collect.log" "collection/${{ inputs.out }}"
           cp "final.csv" "collection/${{ inputs.out }}"
       - uses: JamesIves/github-pages-deploy-action@v4.6.8

--- a/.github/workflows/collect.yml
+++ b/.github/workflows/collect.yml
@@ -98,7 +98,7 @@ jobs:
           id=1
           for file in "${files[@]}"; do
             cp "$file" "collections/${{ inputs.out }}/steps/$(printf '%02d' $i)-$file"
-            id=$((i+1))
+            id=$((id+1))
           done
           cp "collect.log" "collection/${{ inputs.out }}"
           cp "final.csv" "collection/${{ inputs.out }}"

--- a/.github/workflows/collect.yml
+++ b/.github/workflows/collect.yml
@@ -98,7 +98,7 @@ jobs:
           id=1
           for file in "${files[@]}"; do
             cp "$file" "collections/${{ inputs.out }}/steps/$(printf '%02d' $i)-$file"
-            i=$((i+1))
+            id=$((i+1))
           done
           cp "collect.log" "collection/${{ inputs.out }}"
           cp "final.csv" "collection/${{ inputs.out }}"

--- a/.github/workflows/collect.yml
+++ b/.github/workflows/collect.yml
@@ -97,7 +97,7 @@ jobs:
           )
           id=1
           for file in "${files[@]}"; do
-            cp "$file" "collections/${{ inputs.out }}/steps/$(printf '%02d' $i)-$file"
+            cp "$file" "collections/${{ inputs.out }}/steps/$(printf '%02d' "$id")-$file"
             id="$((id+1))"
           done
           cp "collect.log" "collection/${{ inputs.out }}"

--- a/.github/workflows/collect.yml
+++ b/.github/workflows/collect.yml
@@ -98,7 +98,7 @@ jobs:
           id=1
           for file in "${files[@]}"; do
             cp "$file" "collections/${{ inputs.out }}/steps/$(printf '%02d' $i)-$file"
-            id=$((id+1))
+            id="$((id+1))"
           done
           cp "collect.log" "collection/${{ inputs.out }}"
           cp "final.csv" "collection/${{ inputs.out }}"


### PR DESCRIPTION
closes #177

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the `.github/workflows/collect.yml` file to improve the way files are copied into the `collection` directory. It replaces multiple `cp` commands with a loop that dynamically handles file names, ensuring a more organized and scalable approach.

### Detailed summary
- Replaced multiple `cp` commands with a loop that iterates over an array of file names.
- Files are copied into `collection/${{ inputs.out }}/steps/` with a prefixed zero-padded ID.
- Maintained the copying of `collect.log` and `final.csv` to the `collection/${{ inputs.out }}` directory.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->