### PR TITLE
fix(#183): defaults if frame empty

### DIFF
--- a/sr-data/src/sr_data/steps/gh_mentions.py
+++ b/sr-data/src/sr_data/steps/gh_mentions.py
@@ -33,8 +33,12 @@ def main(repos, out):
     logger.info(
         f"Counting GitHub pull request, and issue mentions in {len(frame)} repositories"
     )
-    frame[["readme_pmentions", "readme_imentions"]] = (
-        frame["readme"].apply(mentions)).apply(pd.Series)
+    if frame.empty:
+        frame["readme_pmentions"] = 0
+        frame["readme_imentions"] = 0
+    else:
+        frame[["readme_pmentions", "readme_imentions"]] = (
+            frame["readme"].apply(mentions)).apply(pd.Series)
     frame.to_csv(out, index=False)
     logger.info(f"Saved {len(frame)} repositories to {out}")
 

--- a/sr-data/src/tests/resources/to-ghmentions-empty.csv
+++ b/sr-data/src/tests/resources/to-ghmentions-empty.csv
@@ -1,0 +1,1 @@
+repo,readme

--- a/sr-data/src/tests/test_ghmentions.py
+++ b/sr-data/src/tests/test_ghmentions.py
@@ -79,3 +79,17 @@ class TestGhMentions(unittest.TestCase):
             frame = pd.read_csv(path)
             self.assertEqual(frame.iloc[0]["readme_imentions"], 1)
             self.assertEqual(frame.iloc[0]["readme_pmentions"], 1)
+
+    @pytest.mark.fast
+    def test_returns_zero_records_on_empty_input(self):
+        with TemporaryDirectory() as temp:
+            path = os.path.join(temp, "mentions.csv")
+            main(
+                os.path.join(
+                    os.path.dirname(os.path.realpath(__file__)),
+                    "resources/to-ghmentions-empty.csv"
+                ),
+                path
+            )
+            frame = pd.read_csv(path)
+            self.assertTrue(frame.empty)


### PR DESCRIPTION
closes #183

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enhancing the handling of empty input in the GitHub mentions processing, introducing a test case to ensure that the output is correct when no mentions are available.

### Detailed summary
- Added `to-ghmentions-empty.csv` to test with empty input.
- Introduced `test_returns_zero_records_on_empty_input` in `test_ghmentions.py` to verify behavior with empty input.
- Updated `gh_mentions.py` to set `readme_pmentions` and `readme_imentions` to 0 if the frame is empty.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->