### PR TITLE
fix(#189): apply(bool) if repos are not empty

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,7 +35,7 @@ jobs:
       matrix:
         python-version: [ "3.10", "3.11", "3.12" ]
         poetry-version: [ "1.8.3" ]
-        os: [ ubuntu-22.04, macos-12, windows-2022 ]
+        os: [ ubuntu-22.04, macos-14, windows-2022 ]
         just-version: [ "1.30.1" ]
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,7 +35,7 @@ jobs:
       matrix:
         python-version: [ "3.10", "3.11", "3.12" ]
         poetry-version: [ "1.8.3" ]
-        os: [ ubuntu-22.04, macos-14, windows-2022 ]
+        os: [ ubuntu-22.04, macos-13, windows-2022 ]
         just-version: [ "1.30.1" ]
     runs-on: ${{ matrix.os }}
     steps:

--- a/sr-data/src/tests/resources/to-extract-null-headings.csv
+++ b/sr-data/src/tests/resources/to-extract-null-headings.csv
@@ -1,0 +1,2 @@
+repo,readme
+foo/bar,NULL headings

--- a/sr-data/src/tests/test_extract.py
+++ b/sr-data/src/tests/test_extract.py
@@ -121,3 +121,16 @@ class TestExtract(unittest.TestCase):
             )
             frame = pd.read_csv(path)
             self.assertEqual(frame.iloc[0]["readme_hcount"],3)
+
+    @pytest.mark.fast
+    def test_skips_repo_with_null_headings(self):
+        with TemporaryDirectory() as temp:
+            path = os.path.join(temp, "extracted.csv")
+            main(
+                os.path.join(
+                    os.path.dirname(os.path.realpath(__file__)),
+                    "resources/to-extract-null-headings.csv"
+                ),
+                path
+            )
+            self.assertEqual(len(pd.read_csv(path)), 0)


### PR DESCRIPTION
ref #189

- **feat(#189): test case**
- **feat(#189): remove NaN first**

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enhancing the handling of repositories with null headings in the extraction process, updating the test suite, and making adjustments to the build configuration.

### Detailed summary
- Added a new CSV file `to-extract-null-headings.csv` for testing.
- Updated the `build.yml` to use `macos-13`.
- Introduced a new test `test_skips_repo_with_null_headings` in `test_extract.py`.
- Adjusted the extraction logic in `extract.py` to drop rows with null headings before further processing.
- Ensured that `mcw` is only calculated if `headings` exists in the DataFrame.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->