### PR TITLE
feat(#198): datasets.yml

### DIFF
--- a/.github/workflows/datasets.yml
+++ b/.github/workflows/datasets.yml
@@ -20,7 +20,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 ---
-name: collect
+name: datasets
 'on':
   workflow_dispatch:
     inputs:
@@ -71,16 +71,8 @@ jobs:
             just license_filter "../repos.csv" "../after-license-filter.csv"
             just pulls "../after-license-filter.csv" "$TOKEN" "../repos-with-pulls.csv"
             just filter "../repos-with-pulls.csv" "../after-filter.csv"
-            just mcw "../after-filter.csv" "../after-mcw.csv"
-            just swc "../after-mcw.csv" "../after-swc.csv"
-            just extract "../after-swc.csv" "../after-extract.csv"
-            just snippets "../after-extract.csv" "../after-snippets.csv"
-            just junit "../after-snippets.csv" "$TOKEN" "../after-junit.csv"
-            just maven "../after-junit.csv" "$TOKEN" "../after-maven.csv"
-            just lens "../after-maven.csv" "../after-lens.csv"
-            just links "../after-lens.csv" "../after-links.csv"
-            just ghmentions "../after-links.csv" "../after-ghmentions.csv"
-            just final "../after-ghmentions.csv" "../final.csv"
+            just extract "../after-filter.csv" "../after-extract.csv"
+            just embed "../after-extract.csv" "../embeddings"
           } 2>&1 | tee -a collect.log
           sed -i "s|$TOKEN|REDACTED|g" collect.log
           mkdir -p "collection/${{ inputs.out }}/steps"
@@ -89,15 +81,10 @@ jobs:
             "after-license-filter.csv"
             "repos-with-pulls.csv"
             "after-filter.csv"
-            "after-mcw.csv"
-            "after-swc.csv"
             "after-extract.csv"
-            "after-snippets.csv"
-            "after-maven.csv"
-            "after-junit.csv"
-            "after-lens.csv"
-            "after-links.csv"
-            "after-ghmentions.csv"
+            "embeddings-s-bert-384.csv"
+            "embeddings-e5-1024.csv"
+            "embeddings-embedv3-1024.csv"
           )
           id=1
           for file in "${files[@]}"; do

--- a/.github/workflows/datasets.yml
+++ b/.github/workflows/datasets.yml
@@ -61,7 +61,7 @@ jobs:
       - uses: extractions/setup-just@v2
         with:
           just-version: "1.30.1"
-      - name: Collect
+      - name: Create
         run: |
           echo "${{ secrets.COLLECT_TOKEN_1 }}" >> "$PATS"
           TOKEN="${{ secrets.GITHUB_TOKEN }}"
@@ -75,8 +75,14 @@ jobs:
             just filter "../repos-with-pulls.csv" "../after-filter.csv"
             just extract "../after-filter.csv" "../after-extract.csv"
             just embed "../after-extract.csv" "../embeddings"
+            cp "embeddings-s-bert-384.csv" "sbert.csv"
+            cp "embeddings-e5-1024.csv" "e5.csv"
+            cp "embeddings-embedv3-1024.csv" "embedv3.csv"
+            just datasets "../" "../after-extract.csv"
           } 2>&1 | tee -a collect.log
           sed -i "s|$TOKEN|REDACTED|g" collect.log
+          sed -i "s|$HF_TOKEN|REDACTED|g" collect.log
+          sed -i "s|$COHERE_TOKEN|REDACTED|g" collect.log
           mkdir -p "collection/${{ inputs.out }}/steps"
           files=(
             "repos.csv"
@@ -94,7 +100,13 @@ jobs:
             id="$((id+1))"
           done
           cp "collect.log" "collection/${{ inputs.out }}"
-          cp "final.csv" "collection/${{ inputs.out }}"
+          cp "scores.csv" "collection/${{ inputs.out }}/d1-scores.csv"
+          cp "sbert.csv" "collection/${{ inputs.out }}/d2-sbert.csv"
+          cp "e5.csv" "collection/${{ inputs.out }}/d3-e5.csv"
+          cp "embedv3.csv" "collection/${{ inputs.out }}/d4-embedv3.csv"
+          cp "d5-scores+sbert.csv" "collection/${{ inputs.out }}"
+          cp "d6-scores+e5.csv" "collection/${{ inputs.out }}"
+          cp "d7-scores+embedv3.csv" "collection/${{ inputs.out }}"
       - uses: JamesIves/github-pages-deploy-action@v4.6.9
         with:
           branch: collect

--- a/.github/workflows/datasets.yml
+++ b/.github/workflows/datasets.yml
@@ -45,6 +45,8 @@ name: datasets
 permissions: write-all
 env:
   PATS: pats.txt
+  HF_TOKEN: ${{ secrets.HF_TOKEN }}
+  COHERE_TOKEN: ${{ secrets.COHERE_TOKEN }}
 jobs:
   collect:
     runs-on: ubuntu-24.04

--- a/justfile
+++ b/justfile
@@ -136,28 +136,25 @@ embed repos prefix="experiment/embeddings":
     --hf "$HF_TOKEN" --cohere "$COHERE_TOKEN"
 
 # Create datasets.
-datasets dir="experiment":
-  just numerical "{{dir}}/after-extract.csv"
-  just scores "{{dir}}/after-extract.csv"
-  cp "sr-data/{{dir}}/embeddings-s-bert-384.csv" "sr-data/{{dir}}/sbert.csv"
-  cp "sr-data/{{dir}}/embeddings-e5-1024.csv" "sr-data/{{dir}}/e5.csv"
-  cp "sr-data/{{dir}}/embeddings-embedv3-1024.csv" "sr-data/{{dir}}/embedv3.csv"
-  just combination {{dir}} "{{dir}}/sbert.csv"
-  just combination {{dir}} "{{dir}}/e5.csv"
-  just combination {{dir}} "{{dir}}/embedv3.csv"
+datasets dir="experiment" numbase="after-extract.csv":
+  just numerical "{{dir}}/{{numbase}}" "{{dir}}/numerical.csv"
+  just scores "{{dir}}/{{numbase}}" "{{dir}}/scores.csv"
+  just combination "{{dir}}" "{{dir}}/sbert.csv" "{{dir}}/scores.csv" 5
+  just combination "{{dir}}" "{{dir}}/e5.csv" "{{dir}}/scores.csv" 6
+  just combination "{{dir}}" "{{dir}}/embedv3.csv" "{{dir}}/scores.csv" 7
 
 # Create scores dataset.
 scores repos out="experiment/scores.csv":
-  cd sr-data && poetry poe scores --repos {{repos}} --out {{out}}
+  cd sr-data && poetry poe scores --repos "{{repos}}" --out "{{out}}"
 
 # Create all numerical dataset.
 numerical repos out="experiment/numerical.csv":
-  cd sr-data && poetry poe numerical --repos {{repos}} --out {{out}}
+  cd sr-data && poetry poe numerical --repos "{{repos}}" --out "{{out}}"
 
 # Create dataset from combination.
 combination dir embeddings scores="experiment/scores.csv":
-  cd sr-data && poetry poe combination --scores {{scores}} \
-    --embeddings {{embeddings}} --dir {{dir}}
+  cd sr-data && poetry poe combination --scores "{{scores}}" \
+    --embeddings "{{embeddings}}" --dir "{{dir}}"
 
 # Cluster repositories.
 cluster dir="experiment":

--- a/justfile
+++ b/justfile
@@ -139,9 +139,9 @@ embed repos prefix="experiment/embeddings":
 datasets dir="experiment" numbase="after-extract.csv":
   just numerical "{{dir}}/{{numbase}}" "{{dir}}/numerical.csv"
   just scores "{{dir}}/{{numbase}}" "{{dir}}/scores.csv"
-  just combination "{{dir}}" "{{dir}}/sbert.csv" "{{dir}}/scores.csv" 5
-  just combination "{{dir}}" "{{dir}}/e5.csv" "{{dir}}/scores.csv" 6
-  just combination "{{dir}}" "{{dir}}/embedv3.csv" "{{dir}}/scores.csv" 7
+  just combination "{{dir}}" 5 "{{dir}}/sbert.csv" "{{dir}}/scores.csv"
+  just combination "{{dir}}" 6 "{{dir}}/e5.csv" "{{dir}}/scores.csv"
+  just combination "{{dir}}" 7 "{{dir}}/embedv3.csv" "{{dir}}/scores.csv"
 
 # Create scores dataset.
 scores repos out="experiment/scores.csv":
@@ -152,9 +152,9 @@ numerical repos out="experiment/numerical.csv":
   cd sr-data && poetry poe numerical --repos "{{repos}}" --out "{{out}}"
 
 # Create dataset from combination.
-combination dir embeddings scores="experiment/scores.csv":
+combination dir identifier embeddings scores="experiment/scores.csv":
   cd sr-data && poetry poe combination --scores "{{scores}}" \
-    --embeddings "{{embeddings}}" --dir "{{dir}}"
+    --embeddings "{{embeddings}}" --dir "{{dir}}" --identifier "{{identifier}}"
 
 # Cluster repositories.
 cluster dir="experiment":

--- a/justfile
+++ b/justfile
@@ -132,7 +132,7 @@ final latest out="experiment/final.csv":
 
 # Create embeddings.
 embed repos prefix="experiment/embeddings":
-  cd sr-data && poetry poe embed --repos {{repos}} --prefix {{prefix}} \
+  cd sr-data && poetry poe embed --repos "{{repos}}" --prefix {{prefix}} \
     --hf "$HF_TOKEN" --cohere "$COHERE_TOKEN"
 
 # Create datasets.

--- a/sr-data/pyproject.toml
+++ b/sr-data/pyproject.toml
@@ -74,8 +74,13 @@ script = "sr_data.steps.scores:main(repos, out)"
 args = [{name = "repos"}, {name = "out"}]
 
 [tool.poe.tasks.combination]
-script = "sr_data.steps.combination:main(scores, embeddings, dir)"
-args = [{name = "scores"}, {name = "embeddings"}, {name = "dir"}]
+script = "sr_data.steps.combination:main(scores, embeddings, dir, identifier)"
+args = [
+    {name = "scores"},
+    {name = "embeddings"},
+    {name = "dir"},
+    {name = "identifier"}
+]
 
 [tool.poe.tasks.labels]
 script = "sr_data.steps.labels:main(repos, dir)"

--- a/sr-data/src/sr_data/steps/combination.py
+++ b/sr-data/src/sr_data/steps/combination.py
@@ -39,7 +39,7 @@ def main(scores, embeddings, dir, identifier):
     """
     logger.info(f"Combining {scores} + {embeddings}")
     out = (
-        f"{dir}/{identifier}-{os.path.splitext(os.path.basename(scores))[0]}"
+        f"{dir}/d{identifier}-{os.path.splitext(os.path.basename(scores))[0]}"
         f"+{os.path.splitext(os.path.basename(embeddings))[0]}.csv"
     )
     pd.merge(

--- a/sr-data/src/sr_data/steps/combination.py
+++ b/sr-data/src/sr_data/steps/combination.py
@@ -28,17 +28,18 @@ import pandas as pd
 from loguru import logger
 
 
-def main(scores, embeddings, dir):
+def main(scores, embeddings, dir, identifier):
     """
     Combination of datasets.
     :param scores: Dataset with SR-score
     :param embeddings: Dataset with embeddings
     :param dir: Output directory
+    :param identifier Dataset identifier
     :return:
     """
     logger.info(f"Combining {scores} + {embeddings}")
     out = (
-        f"{dir}/{os.path.splitext(os.path.basename(scores))[0]}"
+        f"{dir}/{identifier}-{os.path.splitext(os.path.basename(scores))[0]}"
         f"+{os.path.splitext(os.path.basename(embeddings))[0]}.csv"
     )
     pd.merge(

--- a/sr-data/src/sr_data/steps/numerical.py
+++ b/sr-data/src/sr_data/steps/numerical.py
@@ -32,10 +32,10 @@ def main(repos, out):
     frame = frame[
         [
             "repo",
-            "releases",
-            "pulls",
-            "issues",
-            "branches"
+            "releases_count",
+            "pulls_count",
+            "open_issues_count",
+            "branches_count"
         ]
     ]
     frame.to_csv(out, index=False)

--- a/sr-data/src/sr_data/steps/scores.py
+++ b/sr-data/src/sr_data/steps/scores.py
@@ -33,10 +33,10 @@ def main(repos, out):
     logger.info("Creating dataset with scores...")
     frame = pd.read_csv(repos)
     frame["score"] = (
-            frame["releases"] * 50 +
-            frame["pulls"] * 7.5 +
-            frame["issues"] * 12.5 +
-            frame["branches"] * 30
+            frame["releases_count"] * 50 +
+            frame["pulls_count"] * 7.5 +
+            frame["open_issues_count"] * 12.5 +
+            frame["branches_count"] * 30
     )
     scores = frame[["repo", "score"]]
     scores.to_csv(out, index=False)

--- a/sr-data/src/tests/resources/to-score.csv
+++ b/sr-data/src/tests/resources/to-score.csv
@@ -1,2 +1,2 @@
-repo,releases,pulls,issues,branches,workflows
+repo,releases_count,pulls_count,open_issues_count,branches_count,workflows
 jeff/foo,0,0,1,3,1

--- a/sr-data/src/tests/test_combination.py
+++ b/sr-data/src/tests/test_combination.py
@@ -42,9 +42,10 @@ class TestCombination(unittest.TestCase):
                     os.path.dirname(os.path.realpath(__file__)),
                     "resources/embeddings.csv"
                 ),
-                temp
+                temp,
+                "1"
             )
-            out = os.path.join(temp, "scores+embeddings.csv")
+            out = os.path.join(temp, "d1-scores+embeddings.csv")
             combination = pd.read_csv(out)
             cols = 5
             self.assertEqual(


### PR DESCRIPTION
In this pull I've added dataset creation into data collection script, and renamed script to `datasets.yml`.

ref #198
History:
- **feat(#198): embed**
- **feat(#198): envs**
- **feat(#198): datasets**
- **feat(#198): names**
- **feat(#198): typo**
- **feat(#198): d**
- **feat(#198): identifier**


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the scoring and combination processes in the data handling scripts, enhancing dataset management, and improving the workflow configuration for better organization and clarity.

### Detailed summary
- Updated `to-score.csv` to include detailed release and issue counts.
- Modified `numerical.py` to reflect new column names.
- Adjusted output filename in `test_combination.py`.
- Changed scoring calculations in `scores.py` to use new column names.
- Enhanced `combination.py` to accept an additional `identifier` parameter.
- Updated `pyproject.toml` to include the new `identifier` in task arguments.
- Refined dataset management in workflows, including renaming and copying files. 
- Changed GitHub Actions workflow name from `collect` to `datasets`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->