### PR TITLE
fix(#218): test that sentiment result is not None

### DIFF
--- a/sr-data/src/sr_data/steps/sentiments.py
+++ b/sr-data/src/sr_data/steps/sentiments.py
@@ -42,13 +42,15 @@ def main(repos, out):
 
 def sentiment(readme):
     description = top(readme)
+    result = None
     try:
-        return stask(description)
+        result = stask(description)
     except RuntimeError:
         logger.error(
             f"Can't parse input description ({len(description)} length)"
         )
         logger.debug(f"Erroneous description: {description}")
+    return result
 
 
 # @todo #153:35min: Extract first 15-20 words from first heading.

--- a/sr-data/src/tests/test_sentiments.py
+++ b/sr-data/src/tests/test_sentiments.py
@@ -94,7 +94,7 @@ class TestSentiments(unittest.TestCase):
     def test_runs_sentiment(self):
         result = sentiment("There is a problem!")
         self.assertTrue(
-            result[0]["label"] is not None,
+            result[0] is not None,
             "Sentiment result is NULL, but it should not!"
         )
 

--- a/sr-data/src/tests/test_sentiments.py
+++ b/sr-data/src/tests/test_sentiments.py
@@ -94,8 +94,8 @@ class TestSentiments(unittest.TestCase):
     def test_runs_sentiment(self):
         result = sentiment("There is a problem!")
         self.assertTrue(
-            "negative" in result[0]["label"],
-            "Sentiment result should be negative, but it wasn't!"
+            result[0]["label"] is not None,
+            "Sentiment result is NULL, but it should not!"
         )
 
     @pytest.mark.nightly
@@ -112,5 +112,5 @@ class TestSentiments(unittest.TestCase):
             frame = pd.read_csv(path)
             self.assertTrue(
                 len(frame["sentiment"].tolist()) != 0,
-                "Sentiments are empty, but they should not be!"
+                "Sentiments are empty, but they should not!"
             )

--- a/sr-data/src/tests/test_sentiments.py
+++ b/sr-data/src/tests/test_sentiments.py
@@ -90,7 +90,7 @@ class TestSentiments(unittest.TestCase):
             f"Extracted description: {extracted} does not match with expected: {expected}"
         )
 
-    @pytest.mark.nightly
+    @pytest.mark.fast
     def test_runs_sentiment(self):
         result = sentiment("There is a problem!")
         self.assertTrue(


### PR DESCRIPTION
In this pull I've updated `test_runs_sentiment` test to check that result is not `None`.

closes #218
History:
- **fix(#218): label not None**
- **fix(#218): result is not None**
- **fix(#218): now fast**
