### PR TITLE
feat(#226): w_jobs, w_oss, w_steps

### DIFF
--- a/sr-data/pyproject.toml
+++ b/sr-data/pyproject.toml
@@ -44,6 +44,7 @@ scikit-fuzzy = "0.5.0"
 markdown-it-py = "3.0.0"
 torch = "2.2.2"
 transformers = "4.41.2"
+pyyaml = "6.0.1"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^8.2.2"

--- a/sr-data/src/sr_data/steps/workflows.py
+++ b/sr-data/src/sr_data/steps/workflows.py
@@ -24,6 +24,7 @@ Collect information about GitHub workflows in the repo.
 # SOFTWARE.
 import pandas as pd
 import requests
+import yaml
 from loguru import logger
 
 
@@ -63,4 +64,7 @@ def main(repos, out):
 #  After we got parsed workflows, we can try to find one that makes releases. Probably,
 #  it can be one, that uses on:push:tags. For instance: <a href="https://github.com/objectionary/eo/blob/master/.github/workflows/telegram.yml">telegram.yml</a>.
 def workflow_info(path) -> str:
-    return requests.get(f"https://raw.githubusercontent.com/{path}").text
+    content = requests.get(f"https://raw.githubusercontent.com/{path}")
+    if content.status_code == 200:
+        yml = yaml.safe_load(content.text)
+        print(yml)

--- a/sr-data/src/sr_data/steps/workflows.py
+++ b/sr-data/src/sr_data/steps/workflows.py
@@ -43,16 +43,23 @@ def main(repos, out):
                 for file in workflows.split(",")
                 if file.endswith((".yml", ".yaml"))
             ]
-        logger.info(f"Repo {repo} has {len(ymls)} *.yml|*.yaml workflows inside .github/workflows")
+        logger.info(
+            f"Repo {repo} has {len(ymls)} *.yml|*.yaml workflows inside .github/workflows")
         for yml in ymls:
             infos.append(
                 workflow_info(
-                    f"{repo}/refs/heads/{branch}/.github/workflows/{yml}"
+                    fetch(
+                        f"{repo}/refs/heads/{branch}/.github/workflows/{yml}"
+                    )
                 )
             )
         frame.at[idx, "workflows"] = infos
     frame.to_csv(out, index=False)
     logger.info(f"Saved repositories to {out}")
+
+
+def fetch(path) -> str:
+    return requests.get(f"https://raw.githubusercontent.com/{path}").text
 
 
 # @todo #75:60min Parse fetched YAML files, and calculate their complexity/strictness.
@@ -63,8 +70,22 @@ def main(repos, out):
 #  We should find workflow that releases the repo artifacts to some target platform.
 #  After we got parsed workflows, we can try to find one that makes releases. Probably,
 #  it can be one, that uses on:push:tags. For instance: <a href="https://github.com/objectionary/eo/blob/master/.github/workflows/telegram.yml">telegram.yml</a>.
-def workflow_info(path) -> str:
-    content = requests.get(f"https://raw.githubusercontent.com/{path}")
-    if content.status_code == 200:
-        yml = yaml.safe_load(content.text)
-        print(yml)
+def workflow_info(content):
+    yml = yaml.safe_load(content)
+    jobs = yml["jobs"].items()
+    jcount = len(jobs)
+    oss = []
+    for job, jdetails in jobs:
+        runs = jdetails.get("runs-on")
+        if runs is not None and runs.startswith("$"):
+            for matrixed in jdetails.get("strategy").get("matrix").get("platform"):
+                oss.append(matrixed)
+        elif runs is not None:
+           oss.append(runs)
+    oss = set(oss)
+    if len(oss) == 1:
+        oss = list(map(lambda x: x.split("-")[0], oss))
+    return {
+        "w_jobs": jcount,
+        "w_doss": len(oss)
+    }

--- a/sr-data/src/sr_data/steps/workflows.py
+++ b/sr-data/src/sr_data/steps/workflows.py
@@ -92,5 +92,5 @@ def workflow_info(content):
         oss = list(map(lambda x: x.split("-")[0], oss))
     return {
         "w_jobs": jcount,
-        "w_doss": len(oss)
+        "w_oss": len(oss)
     }

--- a/sr-data/src/sr_data/steps/workflows.py
+++ b/sr-data/src/sr_data/steps/workflows.py
@@ -62,10 +62,6 @@ def fetch(path) -> str:
     return requests.get(f"https://raw.githubusercontent.com/{path}").text
 
 
-# @todo #75:60min Parse fetched YAML files, and calculate their complexity/strictness.
-#  We should retrieve the following information from fetched workflow: 1) number of
-#  jobs, 2) number of OSs, 3) number of steps in each job, 4) number of versions in
-#  ${{ matrix }}.
 # @todo #75:60min Find release workflow from collected workflows.
 #  We should find workflow that releases the repo artifacts to some target platform.
 #  After we got parsed workflows, we can try to find one that makes releases. Probably,
@@ -75,6 +71,7 @@ def workflow_info(content):
     jobs = yml["jobs"].items()
     jcount = len(jobs)
     oss = []
+    scount = 0
     for job, jdetails in jobs:
         runs = jdetails.get("runs-on")
         if runs is not None and runs.startswith("$"):
@@ -87,10 +84,14 @@ def workflow_info(content):
                 oss.append(matrixed)
         elif runs is not None:
             oss.append(runs)
+        steps = jdetails.get("steps")
+        if steps is not None:
+            scount = len(steps)
     oss = set(oss)
     if len(oss) == 1:
         oss = list(map(lambda x: x.split("-")[0], oss))
     return {
         "w_jobs": jcount,
+        "w_steps": scount,
         "w_oss": len(oss)
     }

--- a/sr-data/src/sr_data/steps/workflows.py
+++ b/sr-data/src/sr_data/steps/workflows.py
@@ -53,7 +53,16 @@ def main(repos, out):
                     )
                 )
             )
-        frame.at[idx, "workflows"] = infos
+        tjobs = 0
+        oss = 0
+        steps = 0
+        for info in infos:
+            tjobs += info["w_jobs"]
+            oss += info["w_oss"]
+            steps += info["w_steps"]
+        frame.at[idx, "w_jobs"] = tjobs
+        frame.at[idx, "w_oss"] = oss
+        frame.at[idx, "w_steps"] = steps
     frame.to_csv(out, index=False)
     logger.info(f"Saved repositories to {out}")
 

--- a/sr-data/src/sr_data/steps/workflows.py
+++ b/sr-data/src/sr_data/steps/workflows.py
@@ -78,10 +78,15 @@ def workflow_info(content):
     for job, jdetails in jobs:
         runs = jdetails.get("runs-on")
         if runs is not None and runs.startswith("$"):
-            for matrixed in jdetails.get("strategy").get("matrix").get("platform"):
+            for matrixed in jdetails.get("strategy").get("matrix").get(
+                    runs.strip()
+                            .replace("${{", "")
+                            .replace("}}", "")
+                            .split(".")[1].strip()
+            ):
                 oss.append(matrixed)
         elif runs is not None:
-           oss.append(runs)
+            oss.append(runs)
     oss = set(oss)
     if len(oss) == 1:
         oss = list(map(lambda x: x.split("-")[0], oss))

--- a/sr-data/src/tests/test_workflows.py
+++ b/sr-data/src/tests/test_workflows.py
@@ -44,6 +44,45 @@ class TestWorkflows(unittest.TestCase):
             f"Fetched workflow information: {info} does not contain expected string: {expected}"
         )
 
+    @pytest.mark.fast
+    def test_outputs_workflow_info_correctly(self):
+        info = workflow_info(
+            """
+name: test
+on:
+  push:
+    branches:
+      - master
+jobs:
+  build:
+    strategy:
+      matrix:
+        os: [ ubuntu-22.04, macos-13, windows-2022, ubuntu-latest, ubuntu-latest ]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v3
+        with:
+          python-version: '3.8'
+      - name: Install dependencies
+        run: pip install -r requirements.txt
+      - name: Run tests
+        run: pytest
+            """
+        )
+        self.assertEqual(
+            info["w_jobs"],
+            1,
+            f"Jobs count in workflow: '{info}' does not match with expected"
+        )
+        self.assertEqual(
+            info["w_oss"],
+            4,
+            f"OSs count in workflow: '{info}' does not match with expected"
+        )
+
     @pytest.mark.nightly
     def test_collects_workflows_for_all(self):
         with TemporaryDirectory() as temp:

--- a/sr-data/src/tests/test_workflows.py
+++ b/sr-data/src/tests/test_workflows.py
@@ -81,6 +81,11 @@ jobs:
             info["w_oss"],
             4,
             f"OSs count in workflow: '{info}' does not match with expected"
+        ),
+        self.assertEqual(
+            info["w_steps"],
+            4,
+            f"Steps count in workflow: '{info}' does not match with expected"
         )
 
     @pytest.mark.nightly

--- a/sr-data/src/tests/test_workflows.py
+++ b/sr-data/src/tests/test_workflows.py
@@ -1,7 +1,6 @@
 """
 Tests for workflows.
 """
-import os.path
 # The MIT License (MIT)
 #
 # Copyright (c) 2024 Aliaksei Bialiauski
@@ -23,6 +22,7 @@ import os.path
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
+import os.path
 import unittest
 from tempfile import TemporaryDirectory
 
@@ -100,10 +100,7 @@ jobs:
                 path
             )
             frame = pd.read_csv(path)
-            collected = len(frame["workflows"])
-            expected = 9
-            self.assertEqual(
-                collected,
-                expected,
-                f"Length of collected workflows: {collected} don't match with expected: {expected}"
+            self.assertTrue(
+                all(col in frame.columns for col in ["w_jobs", "w_oss", "w_steps"]),
+                f"Frame {frame.columns} doesn't have expected columns"
             )

--- a/sr-data/src/tests/test_workflows.py
+++ b/sr-data/src/tests/test_workflows.py
@@ -28,14 +28,14 @@ from tempfile import TemporaryDirectory
 
 import pandas as pd
 import pytest
-from sr_data.steps.workflows import workflow_info, main
+from sr_data.steps.workflows import workflow_info, main, fetch
 
 
 class TestWorkflows(unittest.TestCase):
 
     @pytest.mark.fast
-    def test_outputs_workflow_information(self):
-        info = workflow_info(
+    def test_fetches_workflow_information(self):
+        info = fetch(
             "h1alexbel/h1alexbel/refs/heads/main/.github/workflows/update-readme.yml"
         )
         expected = "jobs:"


### PR DESCRIPTION
In this pull I've implemented parsing for fetched GitHub workflows YAML files. From each file we extracted the following information:

* `w_jobs` (total number of jobs in all workflows)
* `w_oss` (total number of unique OSs in all workflows)
* `w_steps` (total number of steps in all workflows)

closes #226
History:
- **feat(#226): pyyaml**
- **feat(#226): workflow_info + fetch**
- **feat(#226): fetch**
- **feat(#226): runs strip**
- **feat(#226): test passes**
- **feat(#226): steps**
- **feat(#226): cols**


<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces a new dependency, enhances workflow testing, and refines the `workflow_info` function to extract detailed information from YAML workflow files.

### Detailed summary
- Added `pyyaml` dependency to `pyproject.toml`.
- Updated test cases in `test_workflows.py` to include fetching workflow information.
- Added a new test for validating workflow info.
- Modified `fetch` and `workflow_info` functions in `workflows.py` to handle YAML parsing and data extraction.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->