### PR TITLE
feat(#230): w_oss counts unique OSs across all workflow files

### DIFF
--- a/sr-data/src/sr_data/steps/workflows.py
+++ b/sr-data/src/sr_data/steps/workflows.py
@@ -98,8 +98,6 @@ def workflow_info(content):
         if steps is not None:
             scount = len(steps)
     oss = set(oss)
-    if len(oss) == 1:
-        oss = list(map(lambda x: x.split("-")[0], oss))
     return {
         "w_jobs": jcount,
         "w_steps": scount,

--- a/sr-data/src/sr_data/steps/workflows.py
+++ b/sr-data/src/sr_data/steps/workflows.py
@@ -54,14 +54,15 @@ def main(repos, out):
                 )
             )
         tjobs = 0
-        oss = 0
+        oss = []
         steps = 0
         for info in infos:
             tjobs += info["w_jobs"]
-            oss += info["w_oss"]
             steps += info["w_steps"]
+            for os in info["w_oss"]:
+                oss.append(os)
         frame.at[idx, "w_jobs"] = tjobs
-        frame.at[idx, "w_oss"] = oss
+        frame.at[idx, "w_oss"] = len(set(oss))
         frame.at[idx, "w_steps"] = steps
     frame.to_csv(out, index=False)
     logger.info(f"Saved repositories to {out}")
@@ -102,5 +103,5 @@ def workflow_info(content):
     return {
         "w_jobs": jcount,
         "w_steps": scount,
-        "w_oss": len(oss)
+        "w_oss": sorted(oss)
     }

--- a/sr-data/src/tests/resources/to-unique-oss.csv
+++ b/sr-data/src/tests/resources/to-unique-oss.csv
@@ -1,0 +1,2 @@
+repo,branch,workflows
+h1alexbel/fakehub,master,"pdd.yml,just.yml,shell-tests.yml"

--- a/sr-data/src/tests/test_workflows.py
+++ b/sr-data/src/tests/test_workflows.py
@@ -88,6 +88,25 @@ jobs:
             f"Steps count in workflow: '{info}' does not match with expected"
         )
 
+    @pytest.mark.fast
+    def test_collects_unique_oss_across_all_files(self):
+        with TemporaryDirectory() as temp:
+            path = os.path.join(temp, "workflows.csv")
+            main(
+                os.path.join(
+                    os.path.dirname(os.path.realpath(__file__)),
+                    "resources/to-unique-oss.csv"
+                ),
+                path
+            )
+            oss = pd.read_csv(path).iloc[0]["w_oss"]
+            expected = 3
+            self.assertEqual(
+                oss,
+                expected,
+                f"OSS count: {oss} does not match with expected: {expected}"
+            )
+
     @pytest.mark.nightly
     def test_collects_workflows_for_all(self):
         with TemporaryDirectory() as temp:
@@ -101,6 +120,7 @@ jobs:
             )
             frame = pd.read_csv(path)
             self.assertTrue(
-                all(col in frame.columns for col in ["w_jobs", "w_oss", "w_steps"]),
+                all(col in frame.columns for col in
+                    ["w_jobs", "w_oss", "w_steps"]),
                 f"Frame {frame.columns} doesn't have expected columns"
             )

--- a/sr-data/src/tests/test_workflows.py
+++ b/sr-data/src/tests/test_workflows.py
@@ -79,8 +79,8 @@ jobs:
         )
         self.assertEqual(
             info["w_oss"],
-            4,
-            f"OSs count in workflow: '{info}' does not match with expected"
+            ["macos-13", "ubuntu-22.04", "ubuntu-latest", "windows-2022"],
+            f"Workflow OSs: '{info}' does not match with expected"
         ),
         self.assertEqual(
             info["w_steps"],


### PR DESCRIPTION
In this pull I made `w_oss` to count only unique OSs across all workflow files.

closes #230
History:
- **feat(#230): unique**
- **feat(#230): test case for unique**


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enhancing the handling of operating systems (OSS) in workflows, ensuring unique OSS are collected, and improving the related tests for accuracy.

### Detailed summary
- Added `to-unique-oss.csv` file containing sample workflow data.
- Changed `oss` from an integer to a list in `workflows.py`.
- Updated logic to collect unique OSS and store their count.
- Modified return value of `workflow_info` to return sorted unique OSS.
- Updated test assertions in `test_workflows.py` to match new OSS format.
- Added a new test `test_collects_unique_oss_across_all_files` to verify unique OSS collection.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->