### PR TITLE
feat(#227): w_has_releases

### DIFF
--- a/sr-data/src/sr_data/steps/workflows.py
+++ b/sr-data/src/sr_data/steps/workflows.py
@@ -56,14 +56,18 @@ def main(repos, out):
         tjobs = 0
         oss = []
         steps = 0
+        releases = False
         for info in infos:
             tjobs += info["w_jobs"]
             steps += info["w_steps"]
             for os in info["w_oss"]:
                 oss.append(os)
+            if info["w_release"]:
+                releases = True
         frame.at[idx, "w_jobs"] = tjobs
         frame.at[idx, "w_oss"] = len(set(oss))
         frame.at[idx, "w_steps"] = steps
+        frame.at[idx, "w_has_releases"] = releases
     frame.to_csv(out, index=False)
     logger.info(f"Saved repositories to {out}")
 
@@ -72,10 +76,6 @@ def fetch(path) -> str:
     return requests.get(f"https://raw.githubusercontent.com/{path}").text
 
 
-# @todo #75:60min Find release workflow from collected workflows.
-#  We should find workflow that releases the repo artifacts to some target platform.
-#  After we got parsed workflows, we can try to find one that makes releases. Probably,
-#  it can be one, that uses on:push:tags. For instance: <a href="https://github.com/objectionary/eo/blob/master/.github/workflows/telegram.yml">telegram.yml</a>.
 def workflow_info(content):
     yml = yaml.safe_load(content)
     jobs = yml["jobs"].items()

--- a/sr-data/src/sr_data/steps/workflows.py
+++ b/sr-data/src/sr_data/steps/workflows.py
@@ -82,6 +82,12 @@ def workflow_info(content):
     jcount = len(jobs)
     oss = []
     scount = 0
+    release = False
+    on = yml[True]
+    if on is not None:
+        if on.get("release"):
+            for type in on.get("release").get("types"):
+                print(type)
     for job, jdetails in jobs:
         runs = jdetails.get("runs-on")
         if runs is not None and runs.startswith("$"):
@@ -101,5 +107,10 @@ def workflow_info(content):
     return {
         "w_jobs": jcount,
         "w_steps": scount,
-        "w_oss": sorted(oss)
+        "w_oss": sorted(oss),
+        "w_release": release
     }
+
+
+def used_for_releases() -> bool:
+    return False

--- a/sr-data/src/sr_data/steps/workflows.py
+++ b/sr-data/src/sr_data/steps/workflows.py
@@ -82,12 +82,6 @@ def workflow_info(content):
     jcount = len(jobs)
     oss = []
     scount = 0
-    release = False
-    on = yml[True]
-    if on is not None:
-        if on.get("release"):
-            for type in on.get("release").get("types"):
-                print(type)
     for job, jdetails in jobs:
         runs = jdetails.get("runs-on")
         if runs is not None and runs.startswith("$"):
@@ -108,9 +102,20 @@ def workflow_info(content):
         "w_jobs": jcount,
         "w_steps": scount,
         "w_oss": sorted(oss),
-        "w_release": release
+        "w_release": used_for_releases(yml)
     }
 
 
-def used_for_releases() -> bool:
-    return False
+def used_for_releases(yml) -> bool:
+    result = False
+    on = yml[True]
+    if on:
+        if on.get("release"):
+            for type in on.get("release").get("types"):
+                if type == "published":
+                    result = True
+        elif on.get("push"):
+            if on.get("push").get("tags"):
+                if len(on.get("push").get("tags")) >= 1:
+                    result = True
+    return result

--- a/sr-data/src/tests/test_workflows.py
+++ b/sr-data/src/tests/test_workflows.py
@@ -28,7 +28,9 @@ from tempfile import TemporaryDirectory
 
 import pandas as pd
 import pytest
-from sr_data.steps.workflows import workflow_info, main, fetch
+import yaml
+from sr_data.steps.workflows import workflow_info, main, fetch, \
+    used_for_releases
 
 
 class TestWorkflows(unittest.TestCase):
@@ -124,3 +126,18 @@ jobs:
                     ["w_jobs", "w_oss", "w_steps"]),
                 f"Frame {frame.columns} doesn't have expected columns"
             )
+
+    @pytest.mark.fast
+    def test_returns_true_when_workflow_has_type_published(self):
+        self.assertTrue(
+            used_for_releases(
+                yaml.safe_load(
+                    """
+                    on:
+                      release:
+                        types: [published]
+                    """
+                )
+            ),
+            "Workflow should be used for releases, but it wasn't"
+        )

--- a/sr-data/src/tests/test_workflows.py
+++ b/sr-data/src/tests/test_workflows.py
@@ -123,7 +123,7 @@ jobs:
             frame = pd.read_csv(path)
             self.assertTrue(
                 all(col in frame.columns for col in
-                    ["w_jobs", "w_oss", "w_steps"]),
+                    ["w_jobs", "w_oss", "w_steps", "w_has_releases"]),
                 f"Frame {frame.columns} doesn't have expected columns"
             )
 

--- a/sr-data/src/tests/test_workflows.py
+++ b/sr-data/src/tests/test_workflows.py
@@ -141,3 +141,36 @@ jobs:
             ),
             "Workflow should be used for releases, but it wasn't"
         )
+
+    @pytest.mark.fast
+    def test_returns_true_when_workflow_has_push_on_version(self):
+        self.assertTrue(
+            used_for_releases(
+                yaml.safe_load(
+                    """
+                    on:
+                      push:
+                        tags:
+                          - v*
+                    """
+                )
+            ),
+            "Workflow should be used for releases, but it wasn't"
+        )
+
+
+    @pytest.mark.fast
+    def test_returns_false_when_no_release(self):
+        self.assertFalse(
+            used_for_releases(
+                yaml.safe_load(
+                    """
+                    on:
+                      push:
+                        branches:
+                          - master
+                    """
+                )
+            ),
+            "Workflow shouldn't be used for releases, but it was"
+        )


### PR DESCRIPTION
In this pull I've added new column: `w_has_releases`, that identifies does repository's workflow files have release pipeline or not.

closes #227 
History:
- **feat(#227): check for release**
- **feat(#227): used_for_release**
- **feat(#227): test case**
- **feat(#227): more tests**
- **feat(#227): has releases**


<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces functionality to determine if workflows are intended for releases by adding new tests and modifying existing workflow processing logic.

### Detailed summary
- Added `used_for_releases` function to check if a workflow is for releases.
- Updated `workflow_info` to include a `w_release` field.
- Modified CSV output to include `w_has_releases`.
- Added three new tests for release workflows in `test_workflows.py`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->