### PR TITLE
feat(#240): clusterstat recipe for results generation

### DIFF
--- a/justfile
+++ b/justfile
@@ -190,8 +190,8 @@ cluster dir="experiment":
 #  cd sr-train && poetry poe cluster --dataset "experiment/scores+embedv3.csv" --dir {{dir}}
 
 # Statistics about generated clusters.
-clusterstat dir="experiment":
-  cd sr-train && poetry poe clusterstat --dir {{dir}}
+clusterstat out dir="experiment":
+  cd sr-train && poetry poe clusterstat --dir {{dir}} --out {{out}}
 
 # Fill in labels in repositories dataset.
 labels dir="experiment":

--- a/justfile
+++ b/justfile
@@ -179,15 +179,13 @@ combination dir identifier embeddings scores="experiment/scores.csv":
 
 # Cluster repositories.
 cluster dir="experiment":
+  cd sr-train && poetry poe cluster --dataset "experiment/d1-scores.csv" --dir {{dir}}
+  cd sr-train && poetry poe cluster --dataset "experiment/d2-sbert.csv" --dir {{dir}}
+  cd sr-train && poetry poe cluster --dataset "experiment/d3-e5.csv" --dir {{dir}}
+  cd sr-train && poetry poe cluster --dataset "experiment/d4-embedv3.csv" --dir {{dir}}
   cd sr-train && poetry poe cluster --dataset "experiment/d5-scores+sbert.csv" --dir {{dir}}
-#  cd sr-train && poetry poe cluster --dataset "experiment/d2-sbert.csv" --dir {{dir}}
-#  cd sr-train && poetry poe cluster --dataset "experiment/d1-scores.csv" --dir {{dir}}
-#  cd sr-train && poetry poe cluster --dataset "experiment/sbert.csv" --dir {{dir}}
-#  cd sr-train && poetry poe cluster --dataset "experiment/e5.csv" --dir {{dir}}
-#  cd sr-train && poetry poe cluster --dataset "experiment/embedv3.csv" --dir {{dir}}
-#  cd sr-train && poetry poe cluster --dataset "experiment/scores+sbert.csv" --dir {{dir}}
-#  cd sr-train && poetry poe cluster --dataset "experiment/scores+e5.csv" --dir {{dir}}
-#  cd sr-train && poetry poe cluster --dataset "experiment/scores+embedv3.csv" --dir {{dir}}
+  cd sr-train && poetry poe cluster --dataset "experiment/d6-scores+e5.csv" --dir {{dir}}
+  cd sr-train && poetry poe cluster --dataset "experiment/d7-scores+embedv3.csv" --dir {{dir}}
 
 # Statistics about generated clusters.
 clusterstat out dir="experiment":

--- a/justfile
+++ b/justfile
@@ -179,14 +179,19 @@ combination dir identifier embeddings scores="experiment/scores.csv":
 
 # Cluster repositories.
 cluster dir="experiment":
-  cd sr-train && poetry poe cluster --dataset "experiment/numerical.csv" --dir {{dir}}
-  cd sr-train && poetry poe cluster --dataset "experiment/scores.csv" --dir {{dir}}
-  cd sr-train && poetry poe cluster --dataset "experiment/sbert.csv" --dir {{dir}}
-  cd sr-train && poetry poe cluster --dataset "experiment/e5.csv" --dir {{dir}}
-  cd sr-train && poetry poe cluster --dataset "experiment/embedv3.csv" --dir {{dir}}
-  cd sr-train && poetry poe cluster --dataset "experiment/scores+sbert.csv" --dir {{dir}}
-  cd sr-train && poetry poe cluster --dataset "experiment/scores+e5.csv" --dir {{dir}}
-  cd sr-train && poetry poe cluster --dataset "experiment/scores+embedv3.csv" --dir {{dir}}
+  cd sr-train && poetry poe cluster --dataset "experiment/d5-scores+sbert.csv" --dir {{dir}}
+#  cd sr-train && poetry poe cluster --dataset "experiment/d2-sbert.csv" --dir {{dir}}
+#  cd sr-train && poetry poe cluster --dataset "experiment/d1-scores.csv" --dir {{dir}}
+#  cd sr-train && poetry poe cluster --dataset "experiment/sbert.csv" --dir {{dir}}
+#  cd sr-train && poetry poe cluster --dataset "experiment/e5.csv" --dir {{dir}}
+#  cd sr-train && poetry poe cluster --dataset "experiment/embedv3.csv" --dir {{dir}}
+#  cd sr-train && poetry poe cluster --dataset "experiment/scores+sbert.csv" --dir {{dir}}
+#  cd sr-train && poetry poe cluster --dataset "experiment/scores+e5.csv" --dir {{dir}}
+#  cd sr-train && poetry poe cluster --dataset "experiment/scores+embedv3.csv" --dir {{dir}}
+
+# Statistics about generated clusters.
+clusterstat dir="experiment":
+  cd sr-train && poetry poe clusterstat --dir {{dir}}
 
 # Fill in labels in repositories dataset.
 labels dir="experiment":

--- a/sr-train/pyproject.toml
+++ b/sr-train/pyproject.toml
@@ -34,7 +34,11 @@ scikit-learn = "1.5.2"
 
 [tool.poe.tasks.cluster]
 script = "models.cluster:main(dataset, dir)"
-args = [{name = "dataset"}, {name = "dir"}]
+args = [{ name = "dataset" }, { name = "dir" }]
+
+[tool.poe.tasks.clusterstat]
+script = "models.clusterstat:main(dir)"
+args = [{ name = "dir" }]
 
 [build-system]
 requires = ["setuptools", "wheel"]

--- a/sr-train/pyproject.toml
+++ b/sr-train/pyproject.toml
@@ -37,8 +37,8 @@ script = "models.cluster:main(dataset, dir)"
 args = [{ name = "dataset" }, { name = "dir" }]
 
 [tool.poe.tasks.clusterstat]
-script = "models.clusterstat:main(dir)"
-args = [{ name = "dir" }]
+script = "models.clusterstat:main(dir, out)"
+args = [{ name = "dir" }, { name = "out" }]
 
 [build-system]
 requires = ["setuptools", "wheel"]

--- a/sr-train/src/models/clusterstat.py
+++ b/sr-train/src/models/clusterstat.py
@@ -26,7 +26,7 @@ import os
 
 from loguru import logger
 
-def main(dir):
+def main(dir, out):
     logger.info(f"Inspecting dir '{dir}'")
     for model in os.listdir(dir):
         if model in ["kmeans", "agglomerative", "dbscan", "gmm"]:

--- a/sr-train/src/models/clusterstat.py
+++ b/sr-train/src/models/clusterstat.py
@@ -39,4 +39,4 @@ def main(dir):
                         if os.path.isdir(result):
                             for cluster in os.listdir(result):
                                 clusters.append(cluster)
-                    print(f"{model} -> {dataset}: {len(clusters)} clusters")
+                    print(f"{model} -> {dataset}: {len(clusters)} generated clusters")

--- a/sr-train/src/models/clusterstat.py
+++ b/sr-train/src/models/clusterstat.py
@@ -26,8 +26,10 @@ import os
 
 from loguru import logger
 
+
 def main(dir, out):
     logger.info(f"Inspecting dir '{dir}'")
+    facts = []
     for model in os.listdir(dir):
         if model in ["kmeans", "agglomerative", "dbscan", "gmm"]:
             deep = f"{dir}/{model}"
@@ -41,14 +43,17 @@ def main(dir, out):
                             for cluster in os.listdir(result):
                                 path = f"{result}/{cluster}"
                                 if os.path.isfile(path):
-                                    with open(path, 'r') as c:
+                                    with open(path, "r") as c:
                                         count = sum(1 for _ in c)
                                         if not cluster == "-1.txt":
                                             clusters.append(count)
                                         else:
                                             noisy = count
                     lines = ", ".join(map(str, clusters))
-                    report = f"{model} -> {dataset}: {len(clusters)} clusters ({lines})"
+                    fact = f"{model} -> {dataset}: {len(clusters)} clusters ({lines})"
                     if noisy:
-                        report += f" , +{noisy} noisy repos"
-                    print(report)
+                        fact += f" , +{noisy} noisy repos"
+                    facts.append(fact)
+    with open(out, "w") as r:
+        for fact in facts:
+            r.write(fact + "\n")

--- a/sr-train/src/models/clusterstat.py
+++ b/sr-train/src/models/clusterstat.py
@@ -37,7 +37,6 @@ def main(dir, out):
                 clusters = []
                 noisy = None
                 for dataset in os.listdir(deep):
-                    print(dataset)
                     if dataset in ["d1-scores", "d2-sbert", "d5-scores+sbert"]:
                         result = f"{dir}/{model}/{dataset}/clusters"
                         if os.path.isdir(result):

--- a/sr-train/src/models/clusterstat.py
+++ b/sr-train/src/models/clusterstat.py
@@ -33,14 +33,22 @@ def main(dir, out):
             deep = f"{dir}/{model}"
             if os.path.isdir(deep):
                 clusters = []
+                noisy = None
                 for dataset in os.listdir(deep):
                     if dataset in ["d1-scores", "d2-sbert", "d5-scores+sbert"]:
                         result = f"{dir}/{model}/{dataset}/clusters"
                         if os.path.isdir(result):
                             for cluster in os.listdir(result):
                                 path = f"{result}/{cluster}"
-                                if os.path.isfile(path) and not cluster == "-1.txt":
+                                if os.path.isfile(path):
                                     with open(path, 'r') as c:
-                                        clusters.append(sum(1 for _ in c))
+                                        count = sum(1 for _ in c)
+                                        if not cluster == "-1.txt":
+                                            clusters.append(count)
+                                        else:
+                                            noisy = count
                     lines = ", ".join(map(str, clusters))
-                    print(f"{model} -> {dataset}: {len(clusters)} clusters ({lines})")
+                    report = f"{model} -> {dataset}: {len(clusters)} clusters ({lines})"
+                    if noisy:
+                        report += f" , +{noisy} noisy repos"
+                    print(report)

--- a/sr-train/src/models/clusterstat.py
+++ b/sr-train/src/models/clusterstat.py
@@ -1,5 +1,36 @@
-from loguru import logger
+"""
+Statistics about generated clusters.
+"""
+# The MIT License (MIT)
+#
+# Copyright (c) 2024 Aliaksei Bialiauski
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+import os
 
+from loguru import logger
 
 def main(dir):
     logger.info(f"Inspecting dir '{dir}'")
+    for model in os.listdir(dir):
+        deep = f"{dir}/{model}"
+        if os.path.isdir(deep):
+            for nested in os.listdir(deep):
+                if nested in ["d1-scores", "d2-sbert", "d5-scores+sbert"]:
+                    print(f"dataset result: '{nested}' for model {model}")

--- a/sr-train/src/models/clusterstat.py
+++ b/sr-train/src/models/clusterstat.py
@@ -29,8 +29,14 @@ from loguru import logger
 def main(dir):
     logger.info(f"Inspecting dir '{dir}'")
     for model in os.listdir(dir):
-        deep = f"{dir}/{model}"
-        if os.path.isdir(deep):
-            for nested in os.listdir(deep):
-                if nested in ["d1-scores", "d2-sbert", "d5-scores+sbert"]:
-                    print(f"dataset result: '{nested}' for model {model}")
+        if model in ["kmeans", "agglomerative", "dbscan", "gmm"]:
+            deep = f"{dir}/{model}"
+            if os.path.isdir(deep):
+                clusters = []
+                for dataset in os.listdir(deep):
+                    if dataset in ["d1-scores", "d2-sbert", "d5-scores+sbert"]:
+                        result = f"{dir}/{model}/{dataset}/clusters"
+                        if os.path.isdir(result):
+                            for cluster in os.listdir(result):
+                                clusters.append(cluster)
+                    print(f"{model} -> {dataset}: {len(clusters)} clusters")

--- a/sr-train/src/models/clusterstat.py
+++ b/sr-train/src/models/clusterstat.py
@@ -31,12 +31,13 @@ def main(dir, out):
     logger.info(f"Inspecting dir '{dir}'")
     facts = []
     for model in os.listdir(dir):
-        if model in ["kmeans", "agglomerative", "dbscan", "gmm"]:
+        if model in ["kmeans", "agglomerative", "dbscan", "gmm", "to-cluster"]:
             deep = f"{dir}/{model}"
             if os.path.isdir(deep):
                 clusters = []
                 noisy = None
                 for dataset in os.listdir(deep):
+                    print(dataset)
                     if dataset in ["d1-scores", "d2-sbert", "d5-scores+sbert"]:
                         result = f"{dir}/{model}/{dataset}/clusters"
                         if os.path.isdir(result):
@@ -45,15 +46,16 @@ def main(dir, out):
                                 if os.path.isfile(path):
                                     with open(path, "r") as c:
                                         count = sum(1 for _ in c)
-                                        if not cluster == "-1.txt":
+                                        if not cluster == "-1.txt" and not cluster == "config.json":
                                             clusters.append(count)
                                         else:
                                             noisy = count
-                    lines = ", ".join(map(str, clusters))
-                    fact = f"{model} -> {dataset}: {len(clusters)} clusters ({lines})"
-                    if noisy:
-                        fact += f" , +{noisy} noisy repos"
-                    facts.append(fact)
+                    if not dataset == "config.json":
+                        lines = ", ".join(map(str, clusters))
+                        fact = f"{model} -> {dataset}: {len(clusters)} clusters ({lines})"
+                        if noisy:
+                            fact += f" , +{noisy} noisy repos"
+                        facts.append(fact)
     with open(out, "w") as r:
         for fact in facts:
             r.write(fact + "\n")

--- a/sr-train/src/models/clusterstat.py
+++ b/sr-train/src/models/clusterstat.py
@@ -39,4 +39,4 @@ def main(dir):
                         if os.path.isdir(result):
                             for cluster in os.listdir(result):
                                 clusters.append(cluster)
-                    print(f"{model} -> {dataset}: {len(clusters)} generated clusters")
+                    print(f"{model} -> {dataset}: {len(clusters)} clusters")

--- a/sr-train/src/models/clusterstat.py
+++ b/sr-train/src/models/clusterstat.py
@@ -38,5 +38,9 @@ def main(dir, out):
                         result = f"{dir}/{model}/{dataset}/clusters"
                         if os.path.isdir(result):
                             for cluster in os.listdir(result):
-                                clusters.append(cluster)
-                    print(f"{model} -> {dataset}: {len(clusters)} clusters")
+                                path = f"{result}/{cluster}"
+                                if os.path.isfile(path) and not cluster == "-1.txt":
+                                    with open(path, 'r') as c:
+                                        clusters.append(sum(1 for _ in c))
+                    lines = ", ".join(map(str, clusters))
+                    print(f"{model} -> {dataset}: {len(clusters)} clusters ({lines})")

--- a/sr-train/src/models/clusterstat.py
+++ b/sr-train/src/models/clusterstat.py
@@ -1,0 +1,5 @@
+from loguru import logger
+
+
+def main(dir):
+    logger.info(f"Inspecting dir '{dir}'")

--- a/sr-train/src/tests/test_clusterstat.py
+++ b/sr-train/src/tests/test_clusterstat.py
@@ -34,6 +34,10 @@ from models.clusterstat import main
 class TestClusterstat(unittest.TestCase):
 
     @pytest.mark.fast
+    # @todo #240:30min Add test case when clusters are not empty.
+    #  We should add one more test case when clustering model generates clusters.
+    #  To do so, we need to prepare a bigger dataset for model in order to find
+    #  useful centroids and distributed entries close to them.
     def test_generates_report(self):
         with TemporaryDirectory() as temp:
             dbscan(

--- a/sr-train/src/tests/test_clusterstat.py
+++ b/sr-train/src/tests/test_clusterstat.py
@@ -1,0 +1,53 @@
+"""
+Tests for statistics generation.
+"""
+# The MIT License (MIT)
+#
+# Copyright (c) 2024 Aliaksei Bialiauski
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+import os
+import unittest
+from tempfile import TemporaryDirectory
+
+import pytest
+from models.cluster import dbscan
+from models.clusterstat import main
+
+
+class TestClusterstat(unittest.TestCase):
+
+    @pytest.mark.fast
+    def test_generates_report(self):
+        with TemporaryDirectory() as temp:
+            dbscan(
+                os.path.join(
+                    os.path.dirname(os.path.realpath(__file__)),
+                    "resources/to-cluster.csv"
+                ),
+                temp
+            )
+            results = os.path.join(temp, "results.txt")
+            main(temp, results)
+            with open(results, "r") as r:
+                content = r.readlines()
+            self.assertEqual(
+                content,
+        ["to-cluster -> clusters: 0 clusters ()\n"]
+            )


### PR DESCRIPTION
In this pull I've implemented `clusterstat` recipe for report generation about the results, obtained after clustering (number of clusters, number of repos in them, and noise repos).

closes #240 
History:
- **feat(#240): start**
- **feat(#240): simple list**
- **feat(#240): clusters**
- **feat(#240): clusters**
- **feat(#240): simpler**
- **feat(#240): out**
- **feat(#240): lines**
- **feat(#240): noisy repos**
- **feat(#240): write to out**
- **feat(#240): skip config.json**
- **feat(#240): no print**
- **feat(#240): puzzle**
