### PR TITLE
feat(#246): merge.yml

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -47,11 +47,15 @@ jobs:
           just-version: "1.30.1"
       - name: Create
         run: |
-          just install
-          just merge "${{ inputs.datasets }}" "${{ inputs.out }}"
+          mkdir -p "merged/${{ inputs.out }}"
+          {
+            just install
+            just merge "${{ inputs.datasets }}" "merged/${{ inputs.out }}"
+          } 2>&1 | tee -a merge.log
+          cp "merge.log" "merged/${{ inputs.out }}"
       - uses: JamesIves/github-pages-deploy-action@v4.6.9
         with:
           branch: datasets
-          folder: output
+          folder: merged
           clean: false
         if: github.ref == 'refs/heads/master'

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -1,0 +1,57 @@
+# The MIT License (MIT)
+#
+# Copyright (c) 2024 Aliaksei Bialiauski
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+---
+name: merge
+'on':
+  workflow_dispatch:
+    inputs:
+      datasets:
+        description: "List of dataset names to be merged, in a comma-separated format"
+        required: true
+      out:
+        description: "Output dataset name"
+        required: true
+permissions: write-all
+jobs:
+  create:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - uses: abatilo/actions-poetry@v3
+        with:
+          poetry-version: "1.8.3"
+      - uses: extractions/setup-just@v2
+        with:
+          just-version: "1.30.1"
+      - name: Create
+        run: |
+          just install
+          just merge "${{ inputs.datasets }}" "${{ inputs.out }}"
+      - uses: JamesIves/github-pages-deploy-action@v4.6.9
+        with:
+          branch: datasets
+          folder: output
+          clean: false
+        if: github.ref == 'refs/heads/master'

--- a/justfile
+++ b/justfile
@@ -177,6 +177,10 @@ combination dir identifier embeddings scores="experiment/scores.csv":
   cd sr-data && poetry poe combination --scores "{{scores}}" \
     --embeddings "{{embeddings}}" --dir "{{dir}}" --identifier "{{identifier}}"
 
+# Merge datasets into one.
+merge datasets out:
+  cd sr-data && poetry poe merge --datasets "{{datasets}}" --out "{{out}}"
+
 # Cluster repositories.
 cluster dir="experiment":
   cd sr-train && poetry poe cluster --dataset "experiment/d1-scores.csv" --dir {{dir}}

--- a/justfile
+++ b/justfile
@@ -177,7 +177,7 @@ combination dir identifier embeddings scores="experiment/scores.csv":
   cd sr-data && poetry poe combination --scores "{{scores}}" \
     --embeddings "{{embeddings}}" --dir "{{dir}}" --identifier "{{identifier}}"
 
-# Merge datasets into one.
+# Merge dataset folders into one.
 merge datasets out:
   cd sr-data && poetry poe merge --datasets "{{datasets}}" --out "{{out}}"
 

--- a/sr-data/pyproject.toml
+++ b/sr-data/pyproject.toml
@@ -152,6 +152,10 @@ args = [{name = "repos"}, {name = "out"}]
 script = "sr_data.steps.workflows:main(repos, out)"
 args = [{name = "repos"}, {name = "out"}]
 
+[tool.poe.tasks.merge]
+script = "sr_data.steps.merge:main(datasets, out)"
+args = [{name = "datasets"}, {name = "out"}]
+
 [build-system]
 requires = ["setuptools", "wheel"]
 build-backend = "setuptools.build_meta"

--- a/sr-data/src/sr_data/steps/merge.py
+++ b/sr-data/src/sr_data/steps/merge.py
@@ -1,0 +1,2 @@
+def main(datasets, out):
+    print(datasets)

--- a/sr-data/src/sr_data/steps/merge.py
+++ b/sr-data/src/sr_data/steps/merge.py
@@ -1,7 +1,6 @@
 """
 Merge dataset folders into one.
 """
-import os.path
 # The MIT License (MIT)
 #
 # Copyright (c) 2024 Aliaksei Bialiauski
@@ -23,6 +22,7 @@ import os.path
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
+import os.path
 from io import StringIO
 
 import pandas as pd

--- a/sr-data/src/sr_data/steps/merge.py
+++ b/sr-data/src/sr_data/steps/merge.py
@@ -1,2 +1,78 @@
+"""
+Merge dataset folders into one.
+"""
+import os.path
+# The MIT License (MIT)
+#
+# Copyright (c) 2024 Aliaksei Bialiauski
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+from io import StringIO
+
+import pandas as pd
+import requests
+from loguru import logger
+
+DATASETS = [
+    "d1-scores.csv",
+    "d2-sbert.csv",
+    "d3-e5.csv",
+    "d4-embedv3.csv",
+    "d5-scores+sbert.csv",
+    "d6-scores+e5.csv",
+    "d7-scores+embedv3.csv"
+]
+
+
 def main(datasets, out):
-    print(datasets)
+    logger.info("Start merging...")
+    logger.info(f"Folders={datasets}")
+    candidates = {}
+    for folder in datasets.split(","):
+        candidates[folder] = contents(folder)
+    merged = merge(candidates)
+    for file, df in merged.items():
+        path = os.path.join(out, file)
+        df.to_csv(path, index=False)
+        logger.info(f"Saved merged file '{file}' to {path}")
+
+
+def merge(candidates):
+    merged = {}
+    for file in DATASETS:
+        combined = []
+        for folder, files in candidates.items():
+            if file in files:
+                df = files[file]
+                combined.append(df)
+        if combined:
+            merged[file] = pd.concat(combined, ignore_index=True)
+            logger.info(f"Merged file: {file} ({len(merged[file])} rows)")
+    return merged
+
+
+def contents(folder):
+    result = {}
+    for file in DATASETS:
+        content = requests.get(
+            f"https://raw.githubusercontent.com/h1alexbel/sr-detection/refs/heads/gh-pages/{folder}/{file}"
+        ).text
+        result[file] = pd.read_csv(StringIO(content), sep=",")
+        logger.info(f"Fetched {folder}/{file} ({len(result[file])} rows)")
+    return result


### PR DESCRIPTION
In this pull I've created merge script for collected datasets, located in `gh-pages` branch: `merge.yml`.

closes #246
History:
- **feat(#246): start**
- **feat(#246): merge recipe**
- **feat(#246): merges**
- **feat(#246): merge.log**

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces a new feature for merging dataset folders into a single dataset. It adds a `merge` task to the `justfile`, updates the GitHub Actions workflow for merging datasets, and implements the merging logic in the `merge.py` script.

### Detailed summary
- Added `[tool.poe.tasks.merge]` configuration in `pyproject.toml`.
- Introduced `merge` task in the `justfile` for merging datasets.
- Updated `.github/workflows/merge.yml` to define the merge workflow and inputs.
- Added MIT License information to `merge.py`.
- Implemented the `main`, `merge`, and `contents` functions in `merge.py` for dataset merging logic.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->