### PR TITLE
feat(#250): branch options in merge.yml

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -31,7 +31,6 @@ name: merge
         description: "Branch to check for datasets"
         required: true
         type: choice
-        default: false
         options:
           - gh-pages
           - datasets

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -24,9 +24,14 @@ name: merge
 'on':
   workflow_dispatch:
     inputs:
-      datasets:
-        description: "List of dataset names to be merged, in a comma-separated format"
+      folders:
+        description: "List of folder names to be merged, in a comma-separated format"
         required: true
+      branch:
+        description: "Branch to check for datasets"
+        options:
+          - gh-pages
+          - datasets
       out:
         description: "Output dataset name"
         required: true
@@ -50,7 +55,7 @@ jobs:
           mkdir -p "merged/${{ inputs.out }}"
           {
             just install
-            just merge "${{ inputs.datasets }}" "../merged/${{ inputs.out }}"
+            just merge "${{ inputs.folders }}" "../merged/${{ inputs.out }}" "${{ inputs.branch }}"
           } 2>&1 | tee -a merge.log
           cp "merge.log" "merged/${{ inputs.out }}"
       - uses: JamesIves/github-pages-deploy-action@v4.6.9

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -29,6 +29,9 @@ name: merge
         required: true
       branch:
         description: "Branch to check for datasets"
+        required: true
+        type: choice
+        default: false
         options:
           - gh-pages
           - datasets

--- a/justfile
+++ b/justfile
@@ -178,8 +178,9 @@ combination dir identifier embeddings scores="experiment/scores.csv":
     --embeddings "{{embeddings}}" --dir "{{dir}}" --identifier "{{identifier}}"
 
 # Merge dataset folders into one.
-merge datasets out:
-  cd sr-data && poetry poe merge --datasets "{{datasets}}" --out "{{out}}"
+merge datasets out branch:
+  cd sr-data && poetry poe merge --datasets "{{datasets}}" --out "{{out}}" \
+   --branch "{{branch}}"
 
 # Cluster repositories.
 cluster dir="experiment":

--- a/sr-data/pyproject.toml
+++ b/sr-data/pyproject.toml
@@ -153,8 +153,8 @@ script = "sr_data.steps.workflows:main(repos, out)"
 args = [{name = "repos"}, {name = "out"}]
 
 [tool.poe.tasks.merge]
-script = "sr_data.steps.merge:main(datasets, out)"
-args = [{name = "datasets"}, {name = "out"}]
+script = "sr_data.steps.merge:main(datasets, out, branch)"
+args = [{name = "datasets"}, {name = "out"}, {name = "branch"}]
 
 [build-system]
 requires = ["setuptools", "wheel"]

--- a/sr-data/src/sr_data/steps/merge.py
+++ b/sr-data/src/sr_data/steps/merge.py
@@ -40,12 +40,12 @@ DATASETS = [
 ]
 
 
-def main(datasets, out):
+def main(datasets, out, branch):
     logger.info("Start merging...")
     logger.info(f"Folders={datasets}")
     candidates = {}
     for folder in datasets.split(","):
-        candidates[folder] = contents(folder)
+        candidates[folder] = contents(folder, branch)
     merged = merge(candidates)
     for file, df in merged.items():
         path = os.path.join(out, file)
@@ -67,12 +67,12 @@ def merge(candidates):
     return merged
 
 
-def contents(folder):
+def contents(folder, branch):
     result = {}
     for file in DATASETS:
         content = requests.get(
-            f"https://raw.githubusercontent.com/h1alexbel/sr-detection/refs/heads/gh-pages/{folder}/{file}"
+            f"https://raw.githubusercontent.com/h1alexbel/sr-detection/refs/heads/{branch}/{folder}/{file}"
         ).text
         result[file] = pd.read_csv(StringIO(content), sep=",")
-        logger.info(f"Fetched {folder}/{file} ({len(result[file])} rows)")
+        logger.info(f"Fetched @{branch}/{folder}/{file} ({len(result[file])} rows)")
     return result


### PR DESCRIPTION
In this pull I've added branch option to the `merge.yml` workflow: either `gh-pages` or `datasets`.

closes #250
History:
- **feat(#250): branch arg**
- **feat(#250): branch arg 2x**

<!-- start pr-codex -->

---

## PR-Codex overview
This PR enhances the `merge` functionality by adding a `branch` parameter, allowing users to specify which branch to pull datasets from. It updates related scripts, workflow inputs, and logging to accommodate this new feature.

### Detailed summary
- Updated `merge` task in `justfile` to include `branch` parameter.
- Modified the `main` function in `sr_data.steps.merge` to accept `branch`.
- Adjusted the `contents` function to fetch data from the specified `branch`.
- Changed input from `datasets` to `folders` in the GitHub Actions workflow.
- Updated logging to reflect the branch used in fetching datasets.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->