### PR TITLE
feat(#245): workflows pipe

### DIFF
--- a/.github/workflows/datasets.yml
+++ b/.github/workflows/datasets.yml
@@ -24,6 +24,9 @@ name: datasets
 'on':
   workflow_dispatch:
     inputs:
+      steps:
+        description: "Comma-separated names of steps to be executed"
+        required: true
       start:
         description: "Collect repositories created from, in YYYY-MM-D format"
         required: true
@@ -69,7 +72,7 @@ jobs:
             -e GH_TOKEN="${{ secrets.GITHUB_TOKEN }}" \
             -e HF_TOKEN="${{ secrets.HF_TOKEN }}" \
             -e COHERE_TOKEN="${{ secrets.COHERE_TOKEN }}" \
-            -e OUT="${{ inputs.out }}" -e STEPS="pulls,filter,extract,embed" \
+            -e OUT="${{ inputs.out }}" -e STEPS="${{ inputs.steps }}" \
             -e NUMBASE="${{ inputs.numbase }}" h1alexbel/sr-detection
       - uses: JamesIves/github-pages-deploy-action@v4.7.1
         with:

--- a/sr-data/resources/pipeline.json
+++ b/sr-data/resources/pipeline.json
@@ -20,5 +20,9 @@
       "cp \"embeddings-e5-1024.csv\" \"e5.csv\"",
       "cp \"embeddings-embedv3-1024.csv\" \"embedv3.csv\""
     ]
+  },
+  "workflows": {
+    "repos": "@in",
+    "out": "../after-workflows.csv"
   }
 }

--- a/sr-data/src/tests/test_pipeline.py
+++ b/sr-data/src/tests/test_pipeline.py
@@ -76,3 +76,41 @@ class TestPipeline(unittest.TestCase):
                 ],
                 f"Found files: {files} don't match with expected"
             )
+
+    @pytest.mark.fast
+    def test_outputs_pipeline_with_workflows(self):
+        with TemporaryDirectory() as temp:
+            steps = os.path.join(temp, "steps.txt")
+            files = os.path.join(temp, "files.txt")
+            main(
+                os.path.join(
+                    os.path.dirname(os.path.realpath(__file__)),
+                    "../../resources/pipeline.json",
+                ),
+                "pulls,filter,workflows",
+                steps,
+                files
+            )
+            with open(steps, "r") as f:
+                steps = f.readlines()
+            with open(files, "r") as f:
+                files = f.readlines()
+            self.assertEqual(
+                steps,
+                [
+                    'just pulls "../repos.csv" $GH_TOKEN "../repos-with-pulls.csv"\n',
+                    'just filter "../repos-with-pulls.csv" "../after-filter.csv"\n',
+                    'just workflows "../after-filter.csv" "../after-workflows.csv"',
+                ],
+                f"Resulted steps: {steps} don't match with expected"
+            )
+            self.assertEqual(
+                files,
+                [
+                    'repos.csv\n',
+                    'repos-with-pulls.csv\n',
+                    'after-filter.csv\n',
+                    'after-workflows.csv'
+                ],
+                f"Found files: {files} don't match with expected"
+            )


### PR DESCRIPTION
In this pull I've added `workflows` step into `pipeline.json` steps mapping, in order to collect workflows information: `w_has_releases`, `w_steps`, `w_oss`, `w_jobs` about the repository.

ref #245
- **feat(#245): workflows pipe**
- **feat(#245): workflow test case**
- **feat(#245): steps input**
