### PR TITLE
fix(#259): check for `matrix.get(include)` too

### DIFF
--- a/sr-data/src/sr_data/steps/workflows.py
+++ b/sr-data/src/sr_data/steps/workflows.py
@@ -85,13 +85,21 @@ def workflow_info(content):
     for job, jdetails in jobs:
         runs = jdetails.get("runs-on")
         if runs is not None and runs.startswith("$"):
-            for matrixed in jdetails.get("strategy").get("matrix").get(
-                    runs.strip()
+            matrix = jdetails.get("strategy").get("matrix")
+            key = runs.strip().replace("${{", "").replace("}}", "").split(".")[1].strip()
+            if matrix.get(key):
+                for matrixed in matrix.get(key):
+                    oss.append(matrixed)
+            elif matrix.get("include"):
+                for include in matrix.get("include"):
+                    oss.append(
+                        include.get(
+                            runs.strip()
                             .replace("${{", "")
                             .replace("}}", "")
                             .split(".")[1].strip()
-            ):
-                oss.append(matrixed)
+                        )
+                    )
         elif runs is not None:
             oss.append(runs)
         steps = jdetails.get("steps")

--- a/sr-data/src/tests/resources/to-workflows.csv
+++ b/sr-data/src/tests/resources/to-workflows.csv
@@ -8,3 +8,4 @@ LevBeta/Agil,master,
 dcodesdev/rustfinity.com,main,"ci.yaml,rustfinity-runner.yaml"
 gordnzhou/imnes-emulator,main,
 lanylow/honkai-dumper,main,
+BillyDM/vitalium-verb,main,"build.yml"

--- a/sr-data/src/tests/test_workflows.py
+++ b/sr-data/src/tests/test_workflows.py
@@ -109,7 +109,7 @@ jobs:
                 f"OSS count: {oss} does not match with expected: {expected}"
             )
 
-    @pytest.mark.nightly
+    @pytest.mark.fast
     def test_collects_workflows_for_all(self):
         with TemporaryDirectory() as temp:
             path = os.path.join(temp, "workflows.csv")


### PR DESCRIPTION
In this pull I've fixed an issue with matrix parsing with `include` object inside.

ref #259


<!-- start pr-codex -->

---

## PR-Codex overview
This PR modifies test markers, updates a CSV resource, and refines logic in the `workflows.py` file to enhance workflow collection and handling.

### Detailed summary
- Changed test marker from `@pytest.mark.nightly` to `@pytest.mark.fast` in `test_workflows.py`.
- Updated `to-workflows.csv` by adding `BillyDM/vitalium-verb,main,"build.yml"` and removing a line.
- Refined logic in `workflows.py` to better handle `runs` and `matrix` data extraction.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->