### PR TITLE
fix(#264): skip simple `on` list in used_for_releases

### DIFF
--- a/sr-data/src/sr_data/steps/workflows.py
+++ b/sr-data/src/sr_data/steps/workflows.py
@@ -117,7 +117,7 @@ def workflow_info(content):
 def used_for_releases(yml) -> bool:
     result = False
     on = yml[True]
-    if on and not isinstance(on, str):
+    if on and not isinstance(on, str) and not isinstance(on, list):
         if on.get("release"):
             for type in on.get("release").get("types"):
                 if type == "published":

--- a/sr-data/src/tests/test_workflows.py
+++ b/sr-data/src/tests/test_workflows.py
@@ -176,7 +176,7 @@ jobs:
         )
 
     @pytest.mark.fast
-    def test_returns_false_when_on_list(self):
+    def test_returns_false_on_simple_list(self):
         self.assertFalse(
             used_for_releases(
                 yaml.safe_load(

--- a/sr-data/src/tests/test_workflows.py
+++ b/sr-data/src/tests/test_workflows.py
@@ -174,3 +174,16 @@ jobs:
             ),
             "Workflow shouldn't be used for releases, but it was"
         )
+
+    @pytest.mark.fast
+    def test_returns_false_when_on_list(self):
+        self.assertFalse(
+            used_for_releases(
+                yaml.safe_load(
+                    """
+                    on: [push, pull_request]
+                    """
+                )
+            ),
+            "Workflow shouldn't be used for releases, but it was"
+        )


### PR DESCRIPTION
closes #264
History:
- **feat(#264): test case**
- **feat(#264): simple list**


<!-- start pr-codex -->

---

## PR-Codex overview
This PR enhances the `used_for_releases` function in `workflows.py` to handle lists in addition to strings. It also adds a test case in `test_workflows.py` to ensure the function returns `False` when the `on` parameter is a list.

### Detailed summary
- Updated the condition in `workflows.py` to check if `on` is a `list`.
- Added a new test method `test_returns_false_on_simple_list` in `test_workflows.py`.
- The test verifies that `used_for_releases` returns `False` for a list input.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->