### PR TITLE
fix(#266): nested matrix expressions in workflows

### DIFF
--- a/sr-data/src/tests/resources/to-workflows.csv
+++ b/sr-data/src/tests/resources/to-workflows.csv
@@ -10,3 +10,4 @@ gordnzhou/imnes-emulator,main,
 lanylow/honkai-dumper,main,
 BillyDM/vitalium-verb,main,"build.yml"
 polespinasa/bitcoin-grouphug,main,"ci.yml"
+rohaquinlop/complexipy/,main,"CI.yml"

--- a/sr-data/src/tests/test_workflows.py
+++ b/sr-data/src/tests/test_workflows.py
@@ -187,3 +187,51 @@ jobs:
             ),
             "Workflow shouldn't be used for releases, but it was"
         )
+
+    @pytest.mark.fast
+    def test_outputs_workflow_info_with_nested_expression(self):
+        info = workflow_info(
+            """
+name: test
+on:
+  push:
+    branches:
+      - master
+jobs:
+  build:
+    strategy:
+      matrix:
+        platform:
+          - runner: ubuntu-latest
+            target: x86_64
+          - runner: ubuntu-latest
+            target: x86
+    runs-on: ${{ matrix.platform.runner }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v3
+        with:
+          python-version: '3.8'
+      - name: Install dependencies
+        run: pip install -r requirements.txt
+      - name: Run tests
+        run: pytest
+            """
+        )
+        self.assertEqual(
+            info["w_oss"],
+            ["ubuntu-latest@x86", "ubuntu-latest@x86_64"],
+            f"Workflow OSs: '{info}' does not match with expected"
+        )
+        self.assertEqual(
+            info["w_jobs"],
+            1,
+            f"Jobs count in workflow: '{info}' does not match with expected"
+        )
+        self.assertEqual(
+            info["w_steps"],
+            4,
+            f"Steps count in workflow: '{info}' does not match with expected"
+        )


### PR DESCRIPTION
In this pull I've updated workflow parsing logic to handle nested matrix expressions like `${{ matrix.a.b.c }}`.

closes #266
History:
- **fix(#266): dot_values**
- **fix(#266): more test cases**


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enhancing the workflow testing capabilities and refining the matrix handling in the `workflows.py` file. It introduces a new test case for nested workflow expressions and improves the logic for extracting values from matrices.

### Detailed summary
- Added a new test function `test_outputs_workflow_info_with_nested_expression` in `test_workflows.py`.
- Implemented a nested workflow structure for testing.
- Enhanced matrix value extraction logic in `workflows.py` with a new function `dot_values`.
- Improved handling of keys in the matrix extraction process.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->