### PR TITLE
fix(#268): parse group runners in `runs-on` too

### DIFF
--- a/sr-data/src/sr_data/steps/workflows.py
+++ b/sr-data/src/sr_data/steps/workflows.py
@@ -84,30 +84,34 @@ def workflow_info(content):
     scount = 0
     for job, jdetails in jobs:
         runs = jdetails.get("runs-on")
-        if runs is not None and runs.startswith("$"):
-            matrix = jdetails.get("strategy").get("matrix")
-            keys = [
-                key.strip() for key in
-                runs.strip().replace("${{", "").replace("}}", "")
-                .split(".")[1:]
-            ]
-            if len(keys) == 1:
-                if matrix.get(keys[0]):
-                    for matrixed in matrix.get(keys[0]):
-                        oss.append(matrixed)
-            elif len(keys) > 1:
-                for system in dot_values(keys, matrix):
-                    oss.append(system)
-            elif matrix.get("include"):
-                for include in matrix.get("include"):
-                    oss.append(
-                        include.get(
-                            runs.strip()
-                            .replace("${{", "")
-                            .replace("}}", "")
-                            .split(".")[1].strip()
+        if runs is not None and not isinstance(runs, dict):
+            if runs.startswith("$"):
+                matrix = jdetails.get("strategy").get("matrix")
+                keys = [
+                    key.strip() for key in
+                    runs.strip().replace("${{", "").replace("}}", "")
+                    .split(".")[1:]
+                ]
+                if len(keys) == 1:
+                    if matrix.get(keys[0]):
+                        for matrixed in matrix.get(keys[0]):
+                            oss.append(matrixed)
+                elif len(keys) > 1:
+                    for system in dot_values(keys, matrix):
+                        oss.append(system)
+                elif matrix.get("include"):
+                    for include in matrix.get("include"):
+                        oss.append(
+                            include.get(
+                                runs.strip()
+                                .replace("${{", "")
+                                .replace("}}", "")
+                                .split(".")[1].strip()
+                            )
                         )
-                    )
+        elif isinstance(runs, dict):
+            if runs.get("group"):
+                oss.append(runs.get("group"))
         elif runs is not None:
             oss.append(runs)
         steps = jdetails.get("steps")

--- a/sr-data/src/tests/resources/to-workflows.csv
+++ b/sr-data/src/tests/resources/to-workflows.csv
@@ -10,4 +10,5 @@ gordnzhou/imnes-emulator,main,
 lanylow/honkai-dumper,main,
 BillyDM/vitalium-verb,main,"build.yml"
 polespinasa/bitcoin-grouphug,main,"ci.yml"
-rohaquinlop/complexipy/,main,"CI.yml"
+rohaquinlop/complexipy,main,"CI.yml"
+zkVerify/zkVerify,main,"CI-build-test-publish.yml,CI-build.yml,CI-cache-manager.yml,CI-coverage.yml,CI-lint-format.yml,CI-orchestrator.yml,CI-rustdoc.yml,CI-tag-orchestrator.yml,CI-test.yml,CI-zombienet-test.yml"


### PR DESCRIPTION
closes #268

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on modifying the handling of the `runs` attribute in the `workflows.py` file, ensuring proper processing of both string and dictionary types. It also updates the `to-workflows.csv` file to correct a path and add new entries.

### Detailed summary
- Updated `to-workflows.csv` to change the path of `rohaquinlop/complexipy` and add `zkVerify/zkVerify` with multiple CI files.
- In `workflows.py`, changed the condition for `runs` to check if it is not a dictionary.
- Added handling for `runs` when it is a dictionary, specifically checking for the `group` key.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->