### PR TITLE
feat(#245): include workflows to `d0-numerical`

### DIFF
--- a/data.sh
+++ b/data.sh
@@ -49,6 +49,7 @@ for file in "${files[@]}"; do
   id="$((id+1))"
 done
 cp "collect.log" "collection/$OUT"
+cp "numerical.csv" "collection/$OUT/d0-numerical.csv"
 cp "scores.csv" "collection/$OUT/d1-scores.csv"
 cp "sbert.csv" "collection/$OUT/d2-sbert.csv"
 cp "e5.csv" "collection/$OUT/d3-e5.csv"

--- a/ghminer.json
+++ b/ghminer.json
@@ -2,9 +2,9 @@
   "repo": "nameWithOwner",
   "branch": "defaultBranchRef.name",
   "readme": "defaultBranchRef.target.repository.object.text",
-  "releases_count": "releases.totalCount",
-  "open_issues_count": "issues.totalCount",
-  "branches_count": "refs.totalCount",
+  "releases": "releases.totalCount",
+  "open_issues": "issues.totalCount",
+  "branches": "refs.totalCount",
   "license": "licenseInfo.spdxId",
   "workflows": "object.entries[].name"
 }

--- a/sr-data/src/sr_data/steps/numerical.py
+++ b/sr-data/src/sr_data/steps/numerical.py
@@ -32,10 +32,11 @@ def main(repos, out):
     frame = frame[
         [
             "repo",
-            "releases_count",
-            "pulls_count",
-            "open_issues_count",
-            "branches_count"
+            "releases",
+            "pulls",
+            "open_issues",
+            "branches",
+            "workflows"
         ]
     ]
     frame.to_csv(out, index=False)

--- a/sr-data/src/sr_data/steps/pulls.py
+++ b/sr-data/src/sr_data/steps/pulls.py
@@ -31,7 +31,7 @@ from requests import Response
 def main(repos, out, token):
     frame = pd.read_csv(repos)
     for idx, row in frame.iterrows():
-        frame.at[idx, "pulls_count"] = pulls(row["repo"], token)
+        frame.at[idx, "pulls"] = pulls(row["repo"], token)
     frame.to_csv(out, index=False)
 
 

--- a/sr-data/src/sr_data/steps/scores.py
+++ b/sr-data/src/sr_data/steps/scores.py
@@ -33,10 +33,10 @@ def main(repos, out):
     logger.info("Creating dataset with scores...")
     frame = pd.read_csv(repos)
     frame["score"] = (
-            frame["releases_count"] * 50 +
-            frame["pulls_count"] * 7.5 +
-            frame["open_issues_count"] * 12.5 +
-            frame["branches_count"] * 30
+            frame["releases"] * 50 +
+            frame["pulls"] * 7.5 +
+            frame["open_issues"] * 12.5 +
+            frame["branches"] * 30
     )
     scores = frame[["repo", "score"]]
     scores.to_csv(out, index=False)

--- a/sr-data/src/sr_data/steps/workflows.py
+++ b/sr-data/src/sr_data/steps/workflows.py
@@ -64,6 +64,7 @@ def main(repos, out):
                 oss.append(os)
             if info["w_release"]:
                 releases = True
+        frame.at[idx, "workflows"] = len(ymls)
         frame.at[idx, "w_jobs"] = tjobs
         frame.at[idx, "w_oss"] = len(set(oss))
         frame.at[idx, "w_steps"] = steps

--- a/sr-data/src/sr_data/steps/workflows.py
+++ b/sr-data/src/sr_data/steps/workflows.py
@@ -140,7 +140,8 @@ def dot_values(keys, matrix) -> list:
                         if system:
                             extra = [key for key in item if key != k]
                             suffix = "@" + "".join(
-                                str(item.get(d, "")) for d in extra)
+                                str(item.get(d, "")) for d in extra
+                            )
                             result.append(system + suffix)
             else:
                 for item in current:

--- a/sr-data/src/tests/resources/to-score.csv
+++ b/sr-data/src/tests/resources/to-score.csv
@@ -1,2 +1,2 @@
-repo,releases_count,pulls_count,open_issues_count,branches_count,workflows
+repo,releases,pulls,open_issues,branches,workflows
 jeff/foo,0,0,1,3,1

--- a/sr-data/src/tests/test_pulls.py
+++ b/sr-data/src/tests/test_pulls.py
@@ -44,4 +44,4 @@ class TestPulls(unittest.TestCase):
                 path,
                 os.environ["GH_TESTING_TOKEN"]
             )
-            self.assertTrue("pulls_count" in pd.read_csv(path).columns)
+            self.assertTrue("pulls" in pd.read_csv(path).columns)

--- a/sr-data/src/tests/test_workflows.py
+++ b/sr-data/src/tests/test_workflows.py
@@ -142,7 +142,7 @@ jobs:
             result = frame["workflows"].tolist()
             self.assertEqual(
                 result,
-                [4, 0, 2, 1, 1, 0, 2, 0, 0, 1, 1, 1],
+                [4, 0, 2, 1, 1, 0, 2, 0, 0, 1, 1, 1, 10],
                 "Workflows counts don't match with expected"
             )
 

--- a/sr-data/src/tests/test_workflows.py
+++ b/sr-data/src/tests/test_workflows.py
@@ -123,8 +123,27 @@ jobs:
             frame = pd.read_csv(path)
             self.assertTrue(
                 all(col in frame.columns for col in
-                    ["w_jobs", "w_oss", "w_steps", "w_has_releases"]),
+                    ["workflows", "w_jobs", "w_oss", "w_steps", "w_has_releases"]),
                 f"Frame {frame.columns} doesn't have expected columns"
+            )
+
+    @pytest.mark.fast
+    def test_counts_workflows_correctly(self):
+        with TemporaryDirectory() as temp:
+            path = os.path.join(temp, "workflows.csv")
+            main(
+                os.path.join(
+                    os.path.dirname(os.path.realpath(__file__)),
+                    "resources/to-workflows.csv"
+                ),
+                path
+            )
+            frame = pd.read_csv(path)
+            result = frame["workflows"].tolist()
+            self.assertEqual(
+                result,
+                [4, 0, 2, 1, 1, 0, 2, 0, 0, 1, 1, 1],
+                "Workflows counts don't match with expected"
             )
 
     @pytest.mark.fast


### PR DESCRIPTION
In this pull I've added `workflows` count to `d0-numerical.csv` dataset, and simplified naming.

ref #245
History:
- **feat(#245): workflows count**
- **feat(#245): formatting**
- **feat(#245): names**
- **feat(#245): numerical, scores**

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the data handling and processing logic in the `sr-data` project to align with new column names in CSV files, enhancing the workflow management and ensuring accurate data representation.

### Detailed summary
- Updated column names in `to-score.csv` to match new schema.
- Changed references from `pulls_count` to `pulls` in `test_pulls.py`, `pulls.py`, and `scores.py`.
- Adjusted scoring calculations in `scores.py` to use new column names.
- Added copying of `numerical.csv` to the collection in `data.sh`.
- Updated JSON mappings in `ghminer.json` to reflect new field names.
- Enhanced workflow tracking in `workflows.py` by adding workflow counts.
- Introduced a new test in `test_workflows.py` to validate workflow counts.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->