### PR TITLE
fix(#276): stronger workflow parsing

### DIFF
--- a/sr-data/src/sr_data/steps/workflows.py
+++ b/sr-data/src/sr_data/steps/workflows.py
@@ -86,7 +86,10 @@ def workflow_info(content):
     for job, jdetails in jobs:
         runs = jdetails.get("runs-on")
         if runs is not None and not isinstance(runs, dict):
-            if runs.startswith("$"):
+            if isinstance(runs, list):
+                for r in runs:
+                    oss.append(r)
+            if not isinstance(runs, list) and runs.startswith("$"):
                 matrix = jdetails.get("strategy").get("matrix")
                 if isinstance(matrix, str):
                     oss.append(runs)
@@ -113,7 +116,7 @@ def workflow_info(content):
                                     .split(".")[1].strip()
                                 )
                             )
-            else:
+            elif not isinstance(runs, list):
                 oss.append(runs)
         elif isinstance(runs, dict):
             if runs.get("group"):

--- a/sr-data/src/sr_data/steps/workflows.py
+++ b/sr-data/src/sr_data/steps/workflows.py
@@ -103,7 +103,11 @@ def workflow_info(content):
                         if len(keys) == 1:
                             if matrix.get(keys[0]):
                                 for matrixed in matrix.get(keys[0]):
-                                    oss.append(matrixed)
+                                    if isinstance(matrixed, list):
+                                        for r in matrixed:
+                                            oss.append(r)
+                                    else:
+                                        oss.append(matrixed)
                         elif len(keys) > 1:
                             for system in dot_values(keys, matrix):
                                 oss.append(system)

--- a/sr-data/src/sr_data/steps/workflows.py
+++ b/sr-data/src/sr_data/steps/workflows.py
@@ -91,31 +91,32 @@ def workflow_info(content):
                     oss.append(r)
             if not isinstance(runs, list) and runs.startswith("$"):
                 matrix = jdetails.get("strategy").get("matrix")
-                if isinstance(matrix, str):
-                    oss.append(runs)
-                else:
-                    keys = [
-                        key.strip() for key in
-                        runs.strip().replace("${{", "").replace("}}", "")
-                        .split(".")[1:]
-                    ]
-                    if len(keys) == 1:
-                        if matrix.get(keys[0]):
-                            for matrixed in matrix.get(keys[0]):
-                                oss.append(matrixed)
-                    elif len(keys) > 1:
-                        for system in dot_values(keys, matrix):
-                            oss.append(system)
-                    elif matrix.get("include"):
-                        for include in matrix.get("include"):
-                            oss.append(
-                                include.get(
-                                    runs.strip()
-                                    .replace("${{", "")
-                                    .replace("}}", "")
-                                    .split(".")[1].strip()
+                if matrix is not None:
+                    if isinstance(matrix, str):
+                        oss.append(runs)
+                    else:
+                        keys = [
+                            key.strip() for key in
+                            runs.strip().replace("${{", "").replace("}}", "")
+                            .split(".")[1:]
+                        ]
+                        if len(keys) == 1:
+                            if matrix.get(keys[0]):
+                                for matrixed in matrix.get(keys[0]):
+                                    oss.append(matrixed)
+                        elif len(keys) > 1:
+                            for system in dot_values(keys, matrix):
+                                oss.append(system)
+                        elif matrix.get("include"):
+                            for include in matrix.get("include"):
+                                oss.append(
+                                    include.get(
+                                        runs.strip()
+                                        .replace("${{", "")
+                                        .replace("}}", "")
+                                        .split(".")[1].strip()
+                                    )
                                 )
-                            )
             elif not isinstance(runs, list):
                 oss.append(runs)
         elif isinstance(runs, dict):

--- a/sr-data/src/sr_data/steps/workflows.py
+++ b/sr-data/src/sr_data/steps/workflows.py
@@ -90,37 +90,38 @@ def workflow_info(content):
                 for r in runs:
                     oss.append(r)
             if not isinstance(runs, list) and runs.startswith("$"):
-                matrix = jdetails.get("strategy").get("matrix")
-                if matrix is not None:
-                    if isinstance(matrix, str):
-                        oss.append(runs)
-                    else:
-                        keys = [
-                            key.strip() for key in
-                            runs.strip().replace("${{", "").replace("}}", "")
-                            .split(".")[1:]
-                        ]
-                        if len(keys) == 1:
-                            if matrix.get(keys[0]):
-                                for matrixed in matrix.get(keys[0]):
-                                    if isinstance(matrixed, list):
-                                        for r in matrixed:
-                                            oss.append(r)
-                                    else:
-                                        oss.append(matrixed)
-                        elif len(keys) > 1:
-                            for system in dot_values(keys, matrix):
-                                oss.append(system)
-                        elif matrix.get("include"):
-                            for include in matrix.get("include"):
-                                oss.append(
-                                    include.get(
-                                        runs.strip()
-                                        .replace("${{", "")
-                                        .replace("}}", "")
-                                        .split(".")[1].strip()
+                if jdetails.get("strategy"):
+                    matrix = jdetails.get("strategy").get("matrix")
+                    if matrix is not None:
+                        if isinstance(matrix, str):
+                            oss.append(runs)
+                        else:
+                            keys = [
+                                key.strip() for key in
+                                runs.strip().replace("${{", "").replace("}}", "")
+                                .split(".")[1:]
+                            ]
+                            if len(keys) == 1:
+                                if matrix.get(keys[0]):
+                                    for matrixed in matrix.get(keys[0]):
+                                        if isinstance(matrixed, list):
+                                            for r in matrixed:
+                                                oss.append(r)
+                                        else:
+                                            oss.append(matrixed)
+                            elif len(keys) > 1:
+                                for system in dot_values(keys, matrix):
+                                    oss.append(system)
+                            elif matrix.get("include"):
+                                for include in matrix.get("include"):
+                                    oss.append(
+                                        include.get(
+                                            runs.strip()
+                                            .replace("${{", "")
+                                            .replace("}}", "")
+                                            .split(".")[1].strip()
+                                        )
                                     )
-                                )
             elif not isinstance(runs, list):
                 oss.append(runs)
         elif isinstance(runs, dict):

--- a/sr-data/src/sr_data/steps/workflows.py
+++ b/sr-data/src/sr_data/steps/workflows.py
@@ -166,7 +166,10 @@ def dot_values(keys, matrix) -> list:
 
 def used_for_releases(yml) -> bool:
     result = False
-    on = yml[True]
+    if "on" in list(yml.keys()):
+        on = yml["on"]
+    else:
+        on = yml[True]
     if on and not isinstance(on, str) and not isinstance(on, list):
         if on.get("release"):
             for type in on.get("release").get("types"):

--- a/sr-data/src/sr_data/steps/workflows.py
+++ b/sr-data/src/sr_data/steps/workflows.py
@@ -39,7 +39,7 @@ def main(repos, out):
         ymls = []
         if workflows and not isinstance(workflows, float):
             ymls = [
-                file.strip()
+                file
                 for file in workflows.split(",")
                 if file.endswith((".yml", ".yaml"))
             ]

--- a/sr-data/src/tests/test_workflows.py
+++ b/sr-data/src/tests/test_workflows.py
@@ -282,3 +282,36 @@ jobs:
             0,
             f"Steps count in workflow: '{info}' does not match with expected"
         )
+
+    @pytest.mark.fast
+    def test_parses_runs_as_list(self):
+        info = workflow_info(
+            """
+on:
+  pull_request:
+    types: [opened, synchronize]
+jobs:
+  ensure_changelog_exists:
+    name: Ensure that .changeset is not empty
+    runs-on: [ubuntu-latest]
+    strategy:
+      matrix:
+        node-version: ["20.x"]
+        pnpm-version: ["9.x"]
+            """
+        )
+        self.assertEqual(
+            info["w_oss"],
+            ["ubuntu-latest"],
+            f"Workflow OSs: '{info}' does not match with expected"
+        )
+        self.assertEqual(
+            info["w_jobs"],
+            1,
+            f"Jobs count in workflow: '{info}' does not match with expected"
+        )
+        self.assertEqual(
+            info["w_steps"],
+            0,
+            f"Steps count in workflow: '{info}' does not match with expected"
+        )

--- a/sr-data/src/tests/test_workflows.py
+++ b/sr-data/src/tests/test_workflows.py
@@ -315,3 +315,33 @@ jobs:
             0,
             f"Steps count in workflow: '{info}' does not match with expected"
         )
+
+    @pytest.mark.fast
+    def test_parses_on_as_string(self):
+        info = workflow_info(
+            """
+"on":
+  pull_request:
+    types: [push]
+jobs:
+  ensure_changelog_exists:
+    name: test
+    runs-on: [ubuntu-latest]
+            """
+        )
+        self.assertEqual(
+            info["w_oss"],
+            ["ubuntu-latest"],
+            f"Workflow OSs: '{info}' does not match with expected"
+        )
+        self.assertEqual(
+            info["w_jobs"],
+            1,
+            f"Jobs count in workflow: '{info}' does not match with expected"
+        )
+        self.assertEqual(
+            info["w_steps"],
+            0,
+            f"Steps count in workflow: '{info}' does not match with expected"
+        )
+

--- a/sr-data/src/tests/test_workflows.py
+++ b/sr-data/src/tests/test_workflows.py
@@ -369,3 +369,34 @@ jobs:
             0,
             f"Steps count in workflow: '{info}' does not match with expected"
         )
+
+    @pytest.mark.fast
+    def test_parses_oss_as_list_in_matrix(self):
+        info = workflow_info(
+            """
+name: test
+on: push
+jobs:
+  build:
+    strategy:
+      matrix:
+        os:
+          - [self-hosted]          
+    runs-on: ${{ matrix.os }}
+            """
+        )
+        self.assertEqual(
+            info["w_oss"],
+            ["self-hosted"],
+            f"Workflow OSs: '{info}' does not match with expected"
+        )
+        self.assertEqual(
+            info["w_jobs"],
+            1,
+            f"Jobs count in workflow: '{info}' does not match with expected"
+        )
+        self.assertEqual(
+            info["w_steps"],
+            0,
+            f"Steps count in workflow: '{info}' does not match with expected"
+        )

--- a/sr-data/src/tests/test_workflows.py
+++ b/sr-data/src/tests/test_workflows.py
@@ -345,3 +345,27 @@ jobs:
             f"Steps count in workflow: '{info}' does not match with expected"
         )
 
+    def test_parses_non_matrix(self):
+        info = workflow_info(
+            """
+name: test
+jobs:
+  build:
+    runs-on: ${{ inputs.platform }}
+            """
+        )
+        self.assertEqual(
+            info["w_oss"],
+            ["ubuntu-latest"],
+            f"Workflow OSs: '{info}' does not match with expected"
+        )
+        self.assertEqual(
+            info["w_jobs"],
+            1,
+            f"Jobs count in workflow: '{info}' does not match with expected"
+        )
+        self.assertEqual(
+            info["w_steps"],
+            0,
+            f"Steps count in workflow: '{info}' does not match with expected"
+        )

--- a/sr-data/src/tests/test_workflows.py
+++ b/sr-data/src/tests/test_workflows.py
@@ -345,7 +345,7 @@ jobs:
             f"Steps count in workflow: '{info}' does not match with expected"
         )
 
-    def test_parses_non_matrix(self):
+    def test_parses_none_matrix(self):
         info = workflow_info(
             """
 name: test

--- a/sr-data/src/tests/test_workflows.py
+++ b/sr-data/src/tests/test_workflows.py
@@ -345,9 +345,11 @@ jobs:
             f"Steps count in workflow: '{info}' does not match with expected"
         )
 
+    @pytest.mark.fast
     def test_parses_none_matrix(self):
         info = workflow_info(
             """
+on: push
 name: test
 jobs:
   build:
@@ -356,7 +358,7 @@ jobs:
         )
         self.assertEqual(
             info["w_oss"],
-            ["ubuntu-latest"],
+            [],
             f"Workflow OSs: '{info}' does not match with expected"
         )
         self.assertEqual(


### PR DESCRIPTION
closes #276
History:
- **fix(#276): parse runs-on as list**
- **fix(#276): parses on as string**
- **fix(#276): parses non matrix**
- **fix(#276): typo**
- **fix(#276): parses oss as list in matrix**
- **fix(#276): no strip**

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enhancing the handling of `runs-on` in workflows by allowing it to be a list, improving flexibility in job configurations. It also updates the `workflow_info` function to better parse and manage YAML inputs, along with adding corresponding tests.

### Detailed summary
- Modified `workflow_info` to support `runs-on` as a list.
- Updated logic to append values from `runs` based on its type.
- Enhanced handling of matrix configurations within `runs-on`.
- Added new tests to validate parsing of workflows with lists and strings for `runs-on`.
- Included tests for scenarios with no matrix and lists in matrix configurations.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->