### PR TITLE
fix(#279): map `has_release_workflow` to int

### DIFF
--- a/sr-data/src/sr_data/steps/numerical.py
+++ b/sr-data/src/sr_data/steps/numerical.py
@@ -40,5 +40,6 @@ def main(repos, out):
             "has_release_workflow"
         ]
     ]
+    frame["has_release_workflow"] = frame["has_release_workflow"].astype(int)
     frame.to_csv(out, index=False)
     logger.info(f"Numerical dataset created in {out}")

--- a/sr-data/src/tests/resources/to-numerical.csv
+++ b/sr-data/src/tests/resources/to-numerical.csv
@@ -1,0 +1,3 @@
+repo,branch,readme,releases,pulls,open_issues,branches,license,workflows,w_jobs,w_oss,w_steps,has_release_workflow
+foo/bar,master,"",0,0,1,1,"MIT",1,2,3,4,True
+bar/foo,master,"",0,0,1,1,"MIT",1,2,3,4,False

--- a/sr-data/src/tests/test_numerical.py
+++ b/sr-data/src/tests/test_numerical.py
@@ -1,0 +1,72 @@
+"""
+Tests for numerical.
+"""
+# The MIT License (MIT)
+#
+# Copyright (c) 2024 Aliaksei Bialiauski
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+import os
+import unittest
+from tempfile import TemporaryDirectory
+
+import pandas as pd
+import pytest
+from sr_data.steps.numerical import main
+
+
+class TestNumerical(unittest.TestCase):
+
+    @pytest.mark.fast
+    def test_creates_csv_with_numerical(self):
+        with TemporaryDirectory() as temp:
+            path = os.path.join(temp, "numerical.csv")
+            main(
+                os.path.join(
+                    os.path.dirname(os.path.realpath(__file__)),
+                    "resources/to-numerical.csv"
+                ),
+                path
+            )
+            frame = pd.read_csv(path)
+            self.assertTrue(
+                all(
+                    col in frame.columns for col in
+                    [
+                        "repo",
+                        "releases",
+                        "pulls",
+                        "open_issues",
+                        "branches",
+                        "workflows",
+                        "has_release_workflow"
+                    ]
+                ),
+                f"Frame {frame.columns} doesn't have expected columns"
+            )
+            self.assertEqual(
+                frame.iloc[0]["has_release_workflow"],
+                1,
+                "has_release_workflow doesn't match with expected format"
+            )
+            self.assertEqual(
+                frame.iloc[1]["has_release_workflow"],
+                0,
+                "has_release_workflow doesn't match with expected format"
+            )


### PR DESCRIPTION
bool to int:
`True -> 1`
`False -> 0`

closes #279

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enhancing the numerical data processing in the `sr-data` project by adding a new column `has_release_workflow` and improving the corresponding test coverage.

### Detailed summary
- Added a new column `has_release_workflow` in `sr-data/src/sr_data/steps/numerical.py`.
- Updated `to-numerical.csv` with sample data including the `has_release_workflow` field.
- Created a new test class `TestNumerical` in `sr-data/src/tests/test_numerical.py`.
- Implemented a test method `test_creates_csv_with_numerical` to validate the CSV output, ensuring expected columns and values for `has_release_workflow`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->