### PR TITLE
feat(#245): number of junit tests in d0-numercal

### DIFF
--- a/.github/workflows/datasets.yml
+++ b/.github/workflows/datasets.yml
@@ -66,7 +66,7 @@ jobs:
       - name: Create
         run: |
           docker run  --rm -v "$(pwd)/output:/collection" \
-            -e QUERY="stars:>10 language:java,rust size:>=20 mirror:false template:false NOT android" \
+            -e QUERY="stars:>10 language:java size:>=20 mirror:false template:false NOT android" \
             -e START="${{ inputs.start }}" -e END="${{ inputs.end }}" \
             -e COLLECT_TOKEN="${{ secrets.COLLECT_TOKEN_1 }}" \
             -e GH_TOKEN="${{ secrets.GITHUB_TOKEN }}" \

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -43,5 +43,5 @@ jobs:
             -e GH_TOKEN="${{ secrets.GITHUB_TOKEN }}" \
             -e HF_TOKEN="${{ secrets.HF_TOKEN }}" \
             -e COHERE_TOKEN="${{ secrets.COHERE_TOKEN }}" \
-            -e STEPS="pulls,filter,workflows" \
-            -e EMBEDDINGS=false -e NUMBASE="after-workflows.csv" experiment
+            -e STEPS="pulls,filter,workflows,junit" \
+            -e EMBEDDINGS=false -e NUMBASE="after-junit.csv" experiment

--- a/justfile
+++ b/justfile
@@ -198,13 +198,14 @@ dataset folder out:
 
 # Cluster repositories.
 cluster dir out:
-  cd sr-train && poetry poe cluster --dataset "{{dir}}/d1-scores.csv" --dir {{out}}
-  cd sr-train && poetry poe cluster --dataset "{{dir}}/d2-sbert.csv" --dir {{out}}
-  cd sr-train && poetry poe cluster --dataset "{{dir}}/d3-e5.csv" --dir {{out}}
-  cd sr-train && poetry poe cluster --dataset "{{dir}}/d4-embedv3.csv" --dir {{out}}
-  cd sr-train && poetry poe cluster --dataset "{{dir}}/d5-scores+sbert.csv" --dir {{out}}
-  cd sr-train && poetry poe cluster --dataset "{{dir}}/d6-scores+e5.csv" --dir {{out}}
-  cd sr-train && poetry poe cluster --dataset "{{dir}}/d7-scores+embedv3.csv" --dir {{out}}
+  cd sr-train && poetry poe cluster --dataset "{{dir}}/d0-numerical.csv" --dir {{out}}
+#  cd sr-train && poetry poe cluster --dataset "{{dir}}/d1-scores.csv" --dir {{out}}
+#  cd sr-train && poetry poe cluster --dataset "{{dir}}/d2-sbert.csv" --dir {{out}}
+#  cd sr-train && poetry poe cluster --dataset "{{dir}}/d3-e5.csv" --dir {{out}}
+#  cd sr-train && poetry poe cluster --dataset "{{dir}}/d4-embedv3.csv" --dir {{out}}
+#  cd sr-train && poetry poe cluster --dataset "{{dir}}/d5-scores+sbert.csv" --dir {{out}}
+#  cd sr-train && poetry poe cluster --dataset "{{dir}}/d6-scores+e5.csv" --dir {{out}}
+#  cd sr-train && poetry poe cluster --dataset "{{dir}}/d7-scores+embedv3.csv" --dir {{out}}
 
 # Statistics about generated clusters.
 clusterstat out dir="experiment":

--- a/justfile
+++ b/justfile
@@ -199,13 +199,13 @@ dataset folder out:
 # Cluster repositories.
 cluster dir out:
   cd sr-train && poetry poe cluster --dataset "{{dir}}/d0-numerical.csv" --dir {{out}}
-#  cd sr-train && poetry poe cluster --dataset "{{dir}}/d1-scores.csv" --dir {{out}}
-#  cd sr-train && poetry poe cluster --dataset "{{dir}}/d2-sbert.csv" --dir {{out}}
-#  cd sr-train && poetry poe cluster --dataset "{{dir}}/d3-e5.csv" --dir {{out}}
-#  cd sr-train && poetry poe cluster --dataset "{{dir}}/d4-embedv3.csv" --dir {{out}}
-#  cd sr-train && poetry poe cluster --dataset "{{dir}}/d5-scores+sbert.csv" --dir {{out}}
-#  cd sr-train && poetry poe cluster --dataset "{{dir}}/d6-scores+e5.csv" --dir {{out}}
-#  cd sr-train && poetry poe cluster --dataset "{{dir}}/d7-scores+embedv3.csv" --dir {{out}}
+  cd sr-train && poetry poe cluster --dataset "{{dir}}/d1-scores.csv" --dir {{out}}
+  cd sr-train && poetry poe cluster --dataset "{{dir}}/d2-sbert.csv" --dir {{out}}
+  cd sr-train && poetry poe cluster --dataset "{{dir}}/d3-e5.csv" --dir {{out}}
+  cd sr-train && poetry poe cluster --dataset "{{dir}}/d4-embedv3.csv" --dir {{out}}
+  cd sr-train && poetry poe cluster --dataset "{{dir}}/d5-scores+sbert.csv" --dir {{out}}
+  cd sr-train && poetry poe cluster --dataset "{{dir}}/d6-scores+e5.csv" --dir {{out}}
+  cd sr-train && poetry poe cluster --dataset "{{dir}}/d7-scores+embedv3.csv" --dir {{out}}
 
 # Statistics about generated clusters.
 clusterstat out dir="experiment":

--- a/sr-data/resources/pipeline.json
+++ b/sr-data/resources/pipeline.json
@@ -24,5 +24,10 @@
   "workflows": {
     "repos": "@in",
     "out": "../after-workflows.csv"
+  },
+  "junit": {
+    "repos": "@in",
+    "token": "$GH_TOKEN",
+    "out": "../after-junit.csv"
   }
 }

--- a/sr-data/src/sr_data/steps/junit_tests.py
+++ b/sr-data/src/sr_data/steps/junit_tests.py
@@ -40,7 +40,7 @@ def main(repos, out, token):
     frame = pd.read_csv(repos)
     logger.info(f"Counting JUnit tests in {len(frame)} repositories")
     for idx, row in frame.iterrows():
-        frame.at[idx, "junit_tests"] = count_of_tests(
+        frame.at[idx, "tests"] = count_of_tests(
             row["repo"],
             row["branch"],
             token

--- a/sr-data/src/sr_data/steps/numerical.py
+++ b/sr-data/src/sr_data/steps/numerical.py
@@ -37,7 +37,8 @@ def main(repos, out):
             "open_issues",
             "branches",
             "workflows",
-            "has_release_workflow"
+            "has_release_workflow",
+            "tests"
         ]
     ]
     frame["has_release_workflow"] = frame["has_release_workflow"].astype(int)

--- a/sr-data/src/tests/resources/to-numerical.csv
+++ b/sr-data/src/tests/resources/to-numerical.csv
@@ -1,3 +1,3 @@
-repo,branch,readme,releases,pulls,open_issues,branches,license,workflows,w_jobs,w_oss,w_steps,has_release_workflow
-foo/bar,master,"",0,0,1,1,"MIT",1,2,3,4,True
-bar/foo,master,"",0,0,1,1,"MIT",1,2,3,4,False
+repo,branch,readme,releases,pulls,open_issues,branches,license,workflows,w_jobs,w_oss,w_steps,has_release_workflow,tests
+foo/bar,master,"",0,0,1,1,"MIT",1,2,3,4,True,0
+bar/foo,master,"",0,0,1,1,"MIT",1,2,3,4,False,0

--- a/sr-data/src/tests/test_junit_tests.py
+++ b/sr-data/src/tests/test_junit_tests.py
@@ -66,5 +66,5 @@ class TestJunitTests(unittest.TestCase):
                 os.environ["GH_TESTING_TOKEN"]
             )
             frame = pd.read_csv(path)
-            self.assertEqual(frame.iloc[0]["junit_tests"], 187)
-            self.assertEqual(frame.iloc[1]["junit_tests"], 0)
+            self.assertEqual(frame.iloc[0]["tests"], 187)
+            self.assertEqual(frame.iloc[1]["tests"], 0)

--- a/sr-data/src/tests/test_numerical.py
+++ b/sr-data/src/tests/test_numerical.py
@@ -55,7 +55,8 @@ class TestNumerical(unittest.TestCase):
                         "open_issues",
                         "branches",
                         "workflows",
-                        "has_release_workflow"
+                        "has_release_workflow",
+                        "tests"
                     ]
                 ),
                 f"Frame {frame.columns} doesn't have expected columns"


### PR DESCRIPTION
In this pull I've added `junit` step to the SR-data pipeline in order to count a number of JUnit tests.

ref #245
History:
- **feat(#245): junit**
- **feat(#245): docker junit**


<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces modifications primarily related to JUnit test handling and updates the data processing pipeline to include additional test-related metrics. It also adjusts workflow configurations to accommodate these changes.

### Detailed summary
- Added `junit` section in `sr-data/resources/pipeline.json` for JUnit test metrics.
- Updated test cases in `sr-data/src/tests/test_junit_tests.py` to check `tests` instead of `junit_tests`.
- Modified data processing in `sr-data/src/sr_data/steps/junit_tests.py` to store test counts in `tests`.
- Revised `docker.yml` workflow to include `junit` in the steps.
- Updated `to-numerical.csv` to include a `tests` column with relevant data.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->