### PR TITLE
feat(#244): workflow simplicity score

### DIFF
--- a/sr-data/src/sr_data/steps/workflows.py
+++ b/sr-data/src/sr_data/steps/workflows.py
@@ -128,8 +128,7 @@ def workflow_info(content):
                         else:
                             keys = [
                                 key.strip() for key in
-                                runs.strip().replace("${{", "").replace("}}",
-                                                                        "")
+                                runs.strip().replace("${{", "").replace("}}","")
                                 .split(".")[1:]
                             ]
                             if len(keys) == 1:

--- a/sr-data/src/sr_data/steps/workflows.py
+++ b/sr-data/src/sr_data/steps/workflows.py
@@ -128,7 +128,7 @@ def workflow_info(content):
                         else:
                             keys = [
                                 key.strip() for key in
-                                runs.strip().replace("${{", "").replace("}}","")
+                                runs.strip().replace("${{", "").replace("}}", "")
                                 .split(".")[1:]
                             ]
                             if len(keys) == 1:

--- a/sr-data/src/sr_data/steps/workflows.py
+++ b/sr-data/src/sr_data/steps/workflows.py
@@ -66,7 +66,7 @@ def main(repos, out):
             if info["w_release"]:
                 releases = True
         frame.at[idx, "workflows"] = len(ymls)
-        frame["workflows"] = frame["workflows"].astype(int)
+        frame["workflows"] = frame["workflows"]
         frame.at[idx, "w_jobs"] = tjobs
         frame.at[idx, "w_oss"] = len(set(oss))
         frame.at[idx, "w_steps"] = steps

--- a/sr-data/src/sr_data/steps/workflows.py
+++ b/sr-data/src/sr_data/steps/workflows.py
@@ -91,7 +91,7 @@ def w_score(row) -> int:
     @todo #244:35min Enhance workflow simplicity score with min and max adjustment.
      Currently, we just subtract collected value from 1. We should adjust it with
      min and max values from the dataset. So formula should look like:
-     row - min / max - min.
+     1 - (row - min) / (max - min).
     """
     normalized = {
         "workflows": 1 - row["workflows"],

--- a/sr-data/src/tests/resources/to-wscore.csv
+++ b/sr-data/src/tests/resources/to-wscore.csv
@@ -1,0 +1,2 @@
+repo,workflows,w_jobs,w_steps,w_oss,has_release_workflow
+foo/bar,1,2,3,3,0

--- a/sr-data/src/tests/test_workflows.py
+++ b/sr-data/src/tests/test_workflows.py
@@ -89,7 +89,7 @@ jobs:
             f"Steps count in workflow: '{info}' does not match with expected"
         )
 
-    @pytest.mark.fast
+    @pytest.mark.nightly
     def test_collects_unique_oss_across_all_files(self):
         with TemporaryDirectory() as temp:
             path = os.path.join(temp, "workflows.csv")
@@ -108,7 +108,7 @@ jobs:
                 f"OSS count: {oss} does not match with expected: {expected}"
             )
 
-    @pytest.mark.fast
+    @pytest.mark.nightly
     def test_collects_workflows_for_all(self):
         with TemporaryDirectory() as temp:
             path = os.path.join(temp, "workflows.csv")
@@ -128,7 +128,7 @@ jobs:
                 f"Frame {frame.columns} doesn't have expected columns"
             )
 
-    @pytest.mark.fast
+    @pytest.mark.nightly
     def test_counts_workflows_correctly(self):
         with TemporaryDirectory() as temp:
             path = os.path.join(temp, "workflows.csv")
@@ -413,7 +413,7 @@ jobs:
             )
         )
         self.assertEqual(
-            w_score(scores.iloc[0], scores),
-            1.00,
+            w_score(scores.iloc[0]),
+            -0.85,
             "Calculated score does not match with expected"
         )

--- a/sr-data/src/tests/test_workflows.py
+++ b/sr-data/src/tests/test_workflows.py
@@ -29,8 +29,7 @@ from tempfile import TemporaryDirectory
 import pandas as pd
 import pytest
 import yaml
-from sr_data.steps.workflows import workflow_info, main, fetch, \
-    used_for_releases
+from sr_data.steps.workflows import workflow_info, main, fetch, used_for_releases, w_score
 
 
 class TestWorkflows(unittest.TestCase):
@@ -402,4 +401,19 @@ jobs:
             info["w_steps"],
             0,
             f"Steps count in workflow: '{info}' does not match with expected"
+        )
+
+
+    @pytest.mark.fast
+    def test_calculates_simplicity_score(self):
+        scores = pd.read_csv(
+            os.path.join(
+                os.path.dirname(os.path.realpath(__file__)),
+                "resources/to-wscore.csv"
+            )
+        )
+        self.assertEqual(
+            w_score(scores.iloc[0], scores),
+            1.00,
+            "Calculated score does not match with expected"
         )


### PR DESCRIPTION
In this pull I've introduced new calculated metric for GitHub repositories: Workflow Simplicity Score.

closes #244
History:
- **feat(#244): start**
- **feat(#244): simple for now, puzzle**
- **feat(#244): sub**
- **feat(#244): as is**

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces a new feature to calculate a workflow simplicity score based on various metrics from GitHub workflows. It adds a new CSV resource, modifies several tests to run nightly, and updates the `main` function to accommodate these changes.

### Detailed summary
- Added `to-wscore.csv` resource file.
- Updated imports in `test_workflows.py` to include `w_score`.
- Changed test markers from `@pytest.mark.fast` to `@pytest.mark.nightly` for several tests.
- Introduced `test_calculates_simplicity_score` to validate the new scoring functionality.
- Modified `main` function to fill `workflows` with `0` instead of an empty string.
- Added `w_score` function to compute workflow simplicity score.
- Updated data handling in `main` to include `w_simplicity` in the output.
- Adjusted `has_release_workflow` to be an integer in the output CSV.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->