### PR TITLE
feat(#168): filtered.txt

### DIFF
--- a/data.sh
+++ b/data.sh
@@ -51,6 +51,7 @@ done
 cp "collect.log" "collection/$OUT"
 cp "numerical.csv" "collection/$OUT/d0-numerical.csv"
 cp "scores.csv" "collection/$OUT/d1-scores.csv"
+cp "filtered.txt" "collection/$OUT"
 if "$EMBEDDINGS"; then
   cp "sbert.csv" "collection/$OUT/d2-sbert.csv"
   cp "e5.csv" "collection/$OUT/d3-e5.csv"

--- a/justfile
+++ b/justfile
@@ -99,8 +99,8 @@ license_filter repos out="experiment/after-license-filter.csv":
   cd sr-data && poetry poe license_filter --repos "{{repos}}" --out "{{out}}"
 
 # Filter collected repositories.
-filter repos out="experiment/after-filter.csv":
-  cd sr-data && poetry poe filter --repos "{{repos}}" --out "{{out}}"
+filter repos removed out="experiment/after-filter.csv":
+  cd sr-data && poetry poe filter --repos "{{repos}}" --out "{{out}}" --removed "{{removed}}"
 
 # Extract headings from README files.
 extract repos out="experiment/after-extract.csv":

--- a/justfile
+++ b/justfile
@@ -99,8 +99,8 @@ license_filter repos out="experiment/after-license-filter.csv":
   cd sr-data && poetry poe license_filter --repos "{{repos}}" --out "{{out}}"
 
 # Filter collected repositories.
-filter repos removed out="experiment/after-filter.csv":
-  cd sr-data && poetry poe filter --repos "{{repos}}" --out "{{out}}" --removed "{{removed}}"
+filter repos filtered out="experiment/after-filter.csv":
+  cd sr-data && poetry poe filter --repos "{{repos}}" --out "{{out}}" --filtered "{{filtered}}"
 
 # Extract headings from README files.
 extract repos out="experiment/after-extract.csv":

--- a/sr-data/pyproject.toml
+++ b/sr-data/pyproject.toml
@@ -56,8 +56,8 @@ args = [
 ]
 
 [tool.poe.tasks.filter]
-script = "sr_data.steps.filter:main(repos, out)"
-args = [{name = "repos"}, {name = "out"}]
+script = "sr_data.steps.filter:main(repos, out, removed)"
+args = [{name = "repos"}, {name = "out"}, {name = "removed"}]
 
 [tool.poe.tasks.license_filter]
 script = "sr_data.steps.license_filter:main(repos, out)"

--- a/sr-data/pyproject.toml
+++ b/sr-data/pyproject.toml
@@ -56,8 +56,8 @@ args = [
 ]
 
 [tool.poe.tasks.filter]
-script = "sr_data.steps.filter:main(repos, out, removed)"
-args = [{name = "repos"}, {name = "out"}, {name = "removed"}]
+script = "sr_data.steps.filter:main(repos, out, filtered)"
+args = [{name = "repos"}, {name = "out"}, {name = "filtered"}]
 
 [tool.poe.tasks.license_filter]
 script = "sr_data.steps.license_filter:main(repos, out)"

--- a/sr-data/resources/pipeline.json
+++ b/sr-data/resources/pipeline.json
@@ -6,6 +6,7 @@
   },
   "filter": {
     "repos": "@in",
+    "filtered": "../filtered.txt",
     "out": "../after-filter.csv"
   },
   "extract": {

--- a/sr-data/src/sr_data/filtered.py
+++ b/sr-data/src/sr_data/filtered.py
@@ -1,0 +1,30 @@
+"""
+Removed repositories.
+"""
+# The MIT License (MIT)
+#
+# Copyright (c) 2024 Aliaksei Bialiauski
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+def filtered(file, repos, step):
+    file.write(f"Filtered {len(repos)} repositories during ({step}):\n\n")
+    for repo in repos:
+        file.write(f"{repo} ({step})\n")
+    file.write("\n")

--- a/sr-data/src/sr_data/filtered.py
+++ b/sr-data/src/sr_data/filtered.py
@@ -1,5 +1,5 @@
 """
-Removed repositories.
+Filtered repositories.
 """
 # The MIT License (MIT)
 #
@@ -24,7 +24,7 @@ Removed repositories.
 # SOFTWARE.
 
 def filtered(file, repos, step):
-    file.write(f"Filtered {len(repos)} repositories during ({step}):\n\n")
+    file.write(f"Filtered out {len(repos)} repositories during ({step}):\n\n")
     for repo in repos:
         file.write(f"{repo} ({step})\n")
     file.write("\n")

--- a/sr-data/src/sr_data/pipeline.py
+++ b/sr-data/src/sr_data/pipeline.py
@@ -55,6 +55,9 @@ def main(representation, steps, pipes, out):
         if "token" in params:
             token = params["token"]
             command += f" {token}"
+        if "filtered" in params:
+            filtered = params["filtered"]
+            command += f" \"{filtered}\""
         if "out" in params:
             output = params["out"]
             command += f" \"{output}\""

--- a/sr-data/src/sr_data/steps/filter.py
+++ b/sr-data/src/sr_data/steps/filter.py
@@ -46,17 +46,17 @@ def main(repos, out, rm):
     frame = frame.dropna(subset=["readme"])
     non_null = start - len(frame)
     after_null = len(frame)
-    logger.info(f"Filtered {non_null} repositories with empty README files")
+    logger.info(f"Filtered out {non_null} repositories with empty README files")
     frame["readme_text"] = frame["readme"].apply(md_to_text)
     deng = frame[~frame["readme_text"].apply(english)]
     frame = frame[frame["readme_text"].apply(english)]
     frame = frame.drop(columns=["readme_text"])
     non_english = after_null - len(frame)
-    logger.info(f"Filtered {non_english} non-english repositories")
+    logger.info(f"Filtered out {non_english} non-english repositories")
     with open(rm, "w") as f:
         filtered(f, dnull["repo"].tolist(), "filter-null-readme")
         filtered(f, deng["repo"].tolist(), "filter-non-english")
-    logger.info(f"Total skipped: {non_null + non_english}")
+    logger.info(f"Total filtered: {non_null + non_english}")
     frame.to_csv(out, index=False)
     logger.info(f"Saved {len(frame)} good repositories to {out}")
 

--- a/sr-data/src/tests/test_filter.py
+++ b/sr-data/src/tests/test_filter.py
@@ -39,13 +39,15 @@ class TestFilter(unittest.TestCase):
         """
         with TemporaryDirectory() as temp:
             path = os.path.join(temp, "after-filter.csv")
+            filtered = os.path.join(temp, "filtered.txt")
             # pylint: disable=redefined-builtin
             main(
                 os.path.join(
                     os.path.dirname(os.path.realpath(__file__)),
                     "resources/to-filter.csv"
                 ),
-                path
+                path,
+                filtered
             )
             out = pd.read_csv(path)["repo"].values.tolist()
             expected = ["blitz-js/blitz", "wasp-lang/wasp"]
@@ -53,4 +55,8 @@ class TestFilter(unittest.TestCase):
                 out,
                 expected,
                 f"Output CSV {out} does not match with expected {expected}"
+            )
+            self.assertTrue(
+                os.path.exists(filtered),
+                f"File {filtered} does not exist, but it should be"
             )

--- a/sr-data/src/tests/test_filtered.py
+++ b/sr-data/src/tests/test_filtered.py
@@ -1,0 +1,52 @@
+"""
+Tests for filtered.py.
+"""
+# The MIT License (MIT)
+#
+# Copyright (c) 2024 Aliaksei Bialiauski
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+import os.path
+import unittest
+from tempfile import TemporaryDirectory
+
+import pytest
+from sr_data.filtered import filtered
+
+
+class TestFiltered(unittest.TestCase):
+
+    @pytest.mark.fast
+    def test_writes_filtered_repos(self):
+        with TemporaryDirectory() as temp:
+            path = os.path.join(temp, "filtered.txt")
+            with open(path, "w") as f:
+                filtered(f, ["jeff/foo", "jeff/bar"], "test")
+            with open(path, "r") as f:
+                self.assertEqual(
+                    f.readlines(),
+                    [
+                        'Filtered out 2 repositories during (test):\n',
+                        '\n',
+                        'jeff/foo (test)\n',
+                        'jeff/bar (test)\n',
+                        '\n'
+                    ],
+                    f"Content in {filtered} does not match with expected"
+                )

--- a/sr-data/src/tests/test_pipeline.py
+++ b/sr-data/src/tests/test_pipeline.py
@@ -54,7 +54,7 @@ class TestPipeline(unittest.TestCase):
                 steps,
                 [
                     'just pulls "../repos.csv" $GH_TOKEN "../repos-with-pulls.csv"\n',
-                    'just filter "../repos-with-pulls.csv" "../after-filter.csv"\n',
+                    'just filter "../repos-with-pulls.csv" "../filtered.txt" "../after-filter.csv"\n',
                     'just extract "../after-filter.csv" "../after-extract.csv"\n',
                     'just embed "../after-extract.csv" "../embeddings"\n',
                     'cp "embeddings-s-bert-384.csv" "sbert.csv"\n',
@@ -99,7 +99,7 @@ class TestPipeline(unittest.TestCase):
                 steps,
                 [
                     'just pulls "../repos.csv" $GH_TOKEN "../repos-with-pulls.csv"\n',
-                    'just filter "../repos-with-pulls.csv" "../after-filter.csv"\n',
+                    'just filter "../repos-with-pulls.csv" "../filtered.txt" "../after-filter.csv"\n',
                     'just workflows "../after-filter.csv" "../after-workflows.csv"',
                 ],
                 f"Resulted steps: {steps} don't match with expected"


### PR DESCRIPTION
In this pull I've implemented `filtered` function that keep the count of filtered repositories during the step execution.

closes #168
History:
- **feat(#168): filtered**
- **feat(#168): tests**
- **faet(#168): filtered.txt**
- **feat(#168): unit test**
- **feat(#168): filtered file**


<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces a new filtering mechanism for repositories in the pipeline, allowing for better management of filtered data. It updates scripts and adds a new function to log filtered repositories.

### Detailed summary
- Added `filtered` parameter to `pipeline.json`, `filter.py`, and related scripts.
- Updated `main` function in `filter.py` to handle filtering and logging.
- Introduced `filtered.py` for logging filtered repositories.
- Modified test files to validate new filtering functionality.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->