### PR TITLE
bug(#316): default values for commented YAMLs in `workflows.py`

### DIFF
--- a/sr-data/src/tests/test_workflows.py
+++ b/sr-data/src/tests/test_workflows.py
@@ -37,7 +37,7 @@ class TestWorkflows(unittest.TestCase):
     @pytest.mark.fast
     def test_fetches_workflow_information(self):
         info = fetch(
-            "h1alexbel/h1alexbel/refs/heads/main/.github/workflows/update-readme.yml"
+            "h1alexbel/h1alexbel/refs/heads/main/.github/workflows/update-readme.yml",
         )
         expected = "jobs:"
         self.assertTrue(
@@ -407,7 +407,7 @@ jobs:
     strategy:
       matrix:
         os:
-          - [self-hosted]          
+          - [self-hosted]
     runs-on: ${{ matrix.os }}
             """
         )
@@ -440,4 +440,36 @@ jobs:
             w_score(scores.iloc[0]),
             -0.85,
             "Calculated score does not match with expected"
+        )
+
+
+    @pytest.mark.fast
+    def test_parses_commented_workflow(self):
+        info = workflow_info(
+            """
+# name: test
+# on: push
+# jobs:
+#  build:
+#    strategy:
+#      matrix:
+#        os:
+#          - [self-hosted]
+#    runs-on: ${{ matrix.os }}
+            """
+        )
+        self.assertEqual(
+            info["w_oss"],
+            [],
+            "Workflow OSs are not empty, but they should"
+        )
+        self.assertEqual(
+            info["w_jobs"],
+            0,
+            "Jobs count in workflow is not zero, but should be"
+        )
+        self.assertEqual(
+            info["w_steps"],
+            0,
+            "Steps count in workflow is not zero, but should be"
         )


### PR DESCRIPTION
In this pull I've updated `workflows.py` to provide default values for commented YAML workflow files.

see #316

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enhancing the testing of GitHub workflows by adding a new test for parsing commented workflows and improving the `workflow_info` function to handle comments in the YAML content.

### Detailed summary
- Added `test_parses_commented_workflow` to check parsing of commented YAML workflows.
- Updated `workflow_info` to ignore commented lines when parsing YAML content.
- Refactored `workflow_info` to streamline the collection of operating systems and job counts.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->