### PR TITLE
bug(#319): merge d0-numerical

### DIFF
--- a/sr-data/src/sr_data/steps/merge.py
+++ b/sr-data/src/sr_data/steps/merge.py
@@ -41,6 +41,10 @@ DATASETS = [
 ]
 
 
+# @todo #319:45min Setup tests for merge.
+#  Currently, there is no tests that can catch errors in the datasets merging.
+#  Would be crucial to add setup tests that will check the merging functionality,
+#  and help us catch bugs.
 def main(datasets, out, branch):
     logger.info("Start merging...")
     logger.info(f"Folders={datasets}")

--- a/sr-data/src/sr_data/steps/merge.py
+++ b/sr-data/src/sr_data/steps/merge.py
@@ -41,10 +41,11 @@ DATASETS = [
 ]
 
 
-# @todo #319:45min Setup tests for merge.
-#  Currently, there is no tests that can catch errors in the datasets merging.
-#  Would be crucial to add setup tests that will check the merging functionality,
-#  and help us catch bugs.
+# @todo #319:45min Setup unit tests for merge.
+#  Currently, there is no unit tests that can catch errors in the datasets merging,
+#  only an integration test exists in sr-train/test_dataset.py. Would be crucial to
+#  add unit tests too, that will check the merging functionality, and help us catch
+#  bugs faster.
 def main(datasets, out, branch):
     logger.info("Start merging...")
     logger.info(f"Folders={datasets}")

--- a/sr-data/src/sr_data/steps/merge.py
+++ b/sr-data/src/sr_data/steps/merge.py
@@ -30,6 +30,7 @@ import requests
 from loguru import logger
 
 DATASETS = [
+    "d0-numerical.csv",
     "d1-scores.csv",
     "d2-sbert.csv",
     "d3-e5.csv",

--- a/sr-train/src/tests/test_dataset.py
+++ b/sr-train/src/tests/test_dataset.py
@@ -35,10 +35,10 @@ class TestDataset(unittest.TestCase):
     @pytest.mark.deep
     def test_fetches_and_stores_dataset(self):
         with TemporaryDirectory() as temp:
-            main("2024", temp)
+            main("2024-j", temp)
             nfiles = len(os.listdir(temp))
             self.assertEqual(
                 nfiles,
-                7,
+                8,
                 "Number of fetched files doesn't match with expected"
             )


### PR DESCRIPTION
closes #319

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the dataset fetching logic and enhancing the documentation for merging functionality in the codebase.

### Detailed summary
- In `test_dataset.py`, the `main` function call is updated from `"2024"` to `"2024-j"`, resulting in an expected increase in fetched files from 7 to 8.
- In `merge.py`, a new dataset `"d0-numerical.csv"` is added to the `DATASETS` list.
- A `@todo` comment is added to `merge.py`, highlighting the need for unit tests for dataset merging.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->