### PR TITLE
feat(#324): register pipes, prepare out

### DIFF
--- a/sr-filter/src/sr/resources/toolchain.json
+++ b/sr-filter/src/sr/resources/toolchain.json
@@ -1,3 +1,7 @@
 {
-    "goal": ["mine", "pulls", "filter", "workflows", "junit", "package", "cluster", "stats"]
+    "goal": ["pulls", "filter", "workflows", "junit", "package", "cluster", "stats"],
+    "pulls": {
+        "repos": "repos.csv",
+        "out": "sr/target/pulls/repos.csv"
+    }
 }

--- a/sr-filter/src/sr/sr.py
+++ b/sr-filter/src/sr/sr.py
@@ -72,7 +72,7 @@ def main():
         "--steps",
         type=str,
         default="pulls,filter,workflows,junit,package,cluster,stats",
-        help="Comma separeted steps to execute"
+        help="Comma separated steps to execute"
     )
     args = parser.parse_args()
     prepare_out()

--- a/sr-filter/src/sr/sr.py
+++ b/sr-filter/src/sr/sr.py
@@ -28,12 +28,25 @@ import importlib.metadata
 import importlib.resources
 import json
 from loguru import logger
+import os
+import shutil
+
+"""
+Prepare target dir.
+"""
+def prepare_out():
+    out = "sr/target"
+    shutil.rmtree(out)
+    logger.debug(f"Cleaned {out}")
+    os.makedirs(out, exist_ok=True)
+    logger.debug(f"Created output directory in {out}")
 
 
 """
 Register steps.
 """
 def register(steps):
+    pipes = []
     logger.info(f"Registering steps: {steps.replace(",", ", ")}")
     with importlib.resources.files("sr.resources").joinpath("toolchain.json").open("r") as spec:
         tlc = json.load(spec)
@@ -44,7 +57,8 @@ def register(steps):
                 f"Step '{step}' cannot be recognized. List of available steps: {", ".join(defined)}"
             );
             exit(-1);
-    logger.info("Steps registered");
+        pipes.append(step);
+    logger.info("Steps registered")
 
 
 def main():
@@ -57,8 +71,9 @@ def main():
     parser.add_argument(
         "--steps",
         type=str,
-        default="mine,pulls,filter,workflows,junit,package,cluster,stats",
+        default="pulls,filter,workflows,junit,package,cluster,stats",
         help="Comma separeted steps to execute"
     )
     args = parser.parse_args()
+    prepare_out()
     register(args.steps)

--- a/sr-filter/src/sr/sr.py
+++ b/sr-filter/src/sr/sr.py
@@ -41,7 +41,7 @@ def register(steps):
     for step in steps.split(","):
         if not step in defined:
             logger.error(
-                f"Step '{step}' cannot be recongnized. List of available steps: {", ".join(defined)}"
+                f"Step '{step}' cannot be recognized. List of available steps: {", ".join(defined)}"
             );
             exit(-1);
     logger.info("Steps registered");


### PR DESCRIPTION
In this PR I've updated `sr` CLI with scripts that prepares output directory: `sr/target`, and aggregates pipes. Besides that I removed `mine` step from command-line tool.

see #324
History:
- **feat(#324): typo**
- **feat(#324): prepare dirs**

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on modifying the configuration in `toolchain.json` and enhancing the functionality in `sr.py` to prepare an output directory and register steps for processing.

### Detailed summary
- Updated `goal` in `toolchain.json` to remove `"mine"`.
- Added new `pulls` section in `toolchain.json` with `repos` and `out` paths.
- Introduced `prepare_out()` function in `sr.py` to clean and create the output directory.
- Adjusted `register()` function to append steps to `pipes`.
- Changed default `--steps` argument in `main()` to exclude `"mine"`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->